### PR TITLE
Fixed plot poly with array of points

### DIFF
--- a/src/poly.js
+++ b/src/poly.js
@@ -26,7 +26,7 @@ SVG.extend(SVG.Polyline, SVG.Polygon, {
       for (i = 0, l = p.length; i < l; i++)
         points.push(p[i].join(','))
       
-      p = points.length == 0 ? points.join(' ') : '0,0'
+      p = points.length > 0 ? points.join(' ') : '0,0'
     }
     
     return this.attr('points', p || '0,0')


### PR DESCRIPTION
Tried to draw a polyline with an array

```
draw.polyline([[0,1], [100,100], [200,0]])
```

and found an incorrect case statement that was preventing the points from being plotted

```
<polyline id="SvgjsPolyline1294" points="0,0" transform="translate(0,0)"></polyline>
```
