### PR TITLE
Keyword 'default' throws errors in some browsers

### DIFF
--- a/src/default.js
+++ b/src/default.js
@@ -1,5 +1,5 @@
 
-SVG.default = {
+SVG.defaults = {
   // Default matrix
   matrix:       '1,0,0,1,0,0'
   

--- a/src/element.js
+++ b/src/element.js
@@ -4,13 +4,13 @@
 //
 SVG.Element = function(node) {
   /* make stroke value accessible dynamically */
-  this._stroke = SVG.default.attrs.stroke
+  this._stroke = SVG.defaults.attrs.stroke
   
   /* initialize style store */
   this.styles = {}
   
   /* initialize transformation store with defaults */
-  this.trans = SVG.default.trans()
+  this.trans = SVG.defaults.trans()
   
   /* keep reference to the element node */
   if (this.node = node) {
@@ -130,7 +130,7 @@ SVG.extend(SVG.Element, {
       } else {
         v = this.node.getAttribute(a)
         return v == null ? 
-          SVG.default.attrs[a] :
+          SVG.defaults.attrs[a] :
         SVG.regex.test(v, 'isNumber') ?
           parseFloat(v) : v
       }
@@ -213,7 +213,7 @@ SVG.extend(SVG.Element, {
     o = this.trans
     
     /* add matrix */
-    if (o.matrix != SVG.default.matrix)
+    if (o.matrix != SVG.defaults.matrix)
       transform.push('matrix(' + o.matrix + ')')
     
     /* add rotation */


### PR DESCRIPTION
I was doing some browser testing and got this exception in Opera... Annoying for sure but an easy fix.

```
expected identifier, got keyword 'default'
```

Opera
Version
11.52

Build
1100

Platform
Mac OS X

System
10.6.8
