### PR TITLE
Add sub-pixel offset handling

### DIFF
--- a/src/doc.js
+++ b/src/doc.js
@@ -16,7 +16,7 @@ SVG.Doc = function(element) {
     .attr('xlink', SVG.xlink, SVG.ns)
     .defs()
   
-  /* ensure correct rendering for safari */
+  /* ensure correct rendering */
   if (this.parent.nodeName != 'svg')
     this.stage()
 }
@@ -27,6 +27,7 @@ SVG.Doc.prototype = new SVG.Container
 // Hack for safari preventing text to be rendered in one line.
 // Basically it sets the position of the svg node to absolute
 // when the dom is loaded, and resets it to relative a few milliseconds later.
+// Also handles sub-pixel offset rendering properly.
 SVG.Doc.prototype.stage = function() {
   var check
     , element = this
@@ -52,6 +53,9 @@ SVG.Doc.prototype.stage = function() {
         element.node.parentNode.removeChild(element.node)
         element.parent.appendChild(element.node)
         
+        /* after wrapping is done, fix sub-pixel offset */
+        element.fixSubPixelOffset();
+        window.addEventListener('resize', element.fixSubPixelOffset)
       }, 5)
     } else {
       setTimeout(check, 10)
@@ -61,4 +65,14 @@ SVG.Doc.prototype.stage = function() {
   check()
   
   return this
+}
+
+// Fix for possible sub-pixel offset. See:
+// https://bugzilla.mozilla.org/show_bug.cgi?id=608812
+SVG.Doc.prototype.fixSubPixelOffset = function() {
+  var pos  = this.node.getScreenCTM();
+  var left = -pos.e % 1;
+  var top  = -pos.f % 1;
+
+  this.node.style('left: ' + left + 'px;top:' + top + 'px;');
 }


### PR DESCRIPTION
This bugfix takes care of a possible sub-pixel offset of the SVG element. This is because Firefox and Internet Explorer both use the float-position as starting coordinate when rendering the SVG. This leads to lines drawn in sub-pixels which are meant to be drawn in full pixels.

For reference, see https://bugzilla.mozilla.org/show_bug.cgi?id=608812

Beside fixing the offset on load, this fix also recalculates the offset on every window resize, so if the container of the SVG is centered with `margin 0 auto` or percentage positioning, it will stay snapped on pixels.

Basically one would want to recalculate the offset every time the SVG element is moved relative to the 0,0 position of the `<body>`, but we don't have listeners for that, and the alternative of checking the offset periodically every N milliseconds doesn't sound very nice to me.
