### PR TITLE
Fix regex of rgb

### DIFF
--- a/src/regex.js
+++ b/src/regex.js
@@ -12,7 +12,7 @@ SVG.regex = {
 , hex:          /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i
   
   /* parse rgb value */
-, rgb:          /rgb\((\d+),(\d+),(\d+),([\d\.]+)\)/
+, rgb:          /rgb\((\d+),(\d+),(\d+)\)/
   
   /* parse hsb value */
 , hsb:          /hsb\((\d+),(\d+),(\d+),([\d\.]+)\)/


### PR DESCRIPTION
Firefox and IE throws errors with the existing rgb regex.
