### PR TITLE
Save the order of points

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -30,10 +30,8 @@ SVG.extend(SVG.Array, {
   }
   // Clean up any duplicate points
 , settle: function() {
-    var i, seen = []
-
     /* find all unique values */
-    for (i = this.value.length - 1; i >= 0; i--)
+    for (var i = 0, il = this.value.length, seen = []; i < il; i++)
       if (seen.indexOf(this.value[i]) == -1)
         seen.push(this.value[i])
 


### PR DESCRIPTION
Save the order of points. Especially important for animation.
Example:

draw.polyline([[0,0],[10,0],[20,0],[30,0],[40,0]]).fill('none').stroke({
 color: '#222', width: 1 })
    .animate(200)
    .plot([[5,0],[10,0],[20,10],[30,0],[35,0]]);
