### PR TITLE
Fix exception raised with non-in-DOM elements or hidden DOM elements

### DIFF
--- a/src/doc.js
+++ b/src/doc.js
@@ -88,6 +88,8 @@ SVG.extend(SVG.Doc, {
   // https://bugzilla.mozilla.org/show_bug.cgi?id=608812
 , fixSubPixelOffset: function() {
     var pos = this.node.getScreenCTM()
+
+    if (!pos) return
   
     this
       .style('left', (-pos.e % 1) + 'px')


### PR DESCRIPTION
Using an SVG with a non-in-DOM element or with a hidden (display: none) DOM element causes an exception:

```
<div id="el_with_display_none" style="display:none"></div>
var div = document.createElement("div")
// or div = ("el_with_display_none")
var draw = SVG(div).size(300, 300)
var rect = draw.rect(100, 100).attr({ fill: '#f06' })
#=> svg.js (riga 2107): TypeError: pos is null
```
