### PR TITLE
Update mask.js

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -36,7 +36,7 @@ SVG.extend(SVG.Element, {
     this.masker.targets.push(this)
     
     /* apply mask */
-    return this.attr('mask', 'url("#' + this.masker.attr('id') + '")')
+    return this.attr('mask', 'url(' + window.location.href + "#' + this.masker.attr('id') + '")')
   }
   // Unmask element
 , unmask: function() {


### PR DESCRIPTION
when base tag is used in html - masks don't work, because changes the way how masked elements search for their mask ids, to fix this we need to add full path to url() of mask
