### PR TITLE
Don't display parser

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1,4 +1,3 @@
-
 // The main wrapping element
 this.SVG = function(element) {
   if (SVG.supported) {
@@ -70,7 +69,7 @@ SVG.prepare = function(element) {
   /* create parser object */
   SVG.parser = {
     body: body || element.parent
-  , draw: draw.style('opacity:0;position:fixed;left:100%;top:100%;overflow:hidden')
+  , draw: draw.style('display:none;opacity:0;position:fixed;left:100%;top:100%;overflow:hidden')
   , poly: draw.polygon().node
   , path: draw.path().node
   }


### PR DESCRIPTION
Any reason for leaving out `display: none`?
I'm trying to have a full screen SVG element with no scrolling and the parser is making it scroll a tiny bit.

Alternatively the size of the element could be set to `0, 0` but in case it's on purpose, I didn't touch it.
