### PR TITLE
Fix in style() method

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -1,3 +1,4 @@
+
 SVG.Element = SVG.invent({
   // Initialize node
   create: function(node) {


### PR DESCRIPTION
Setting the style of an element with a css string that has multiple properties did not work correct:

```
element.style('opacity:0;position:fixed;left:100%;top:100%;overflow:hidden')
```

Only the first property (opacity) was assigned to the element as expected. The other ones were ignored by the code.
