### PR TITLE
.animation() .stop(true) now fires .after() callback if present

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -368,8 +368,10 @@ SVG.FX = SVG.invent({
   , stop: function(fulfill) {
       /* fulfill animation */
       if (fulfill === true) {
-        this.animate(0)
-
+        this.animate(0);
+        if (this._after) {
+          this._after.apply(this);
+        }
       } else {
         /* stop current animation */
         clearTimeout(this.timeout)


### PR DESCRIPTION
Before: click+hoverout animations collide each other, after callback don't fire, animations stucked in the middle.
After: you can explicitly use .stop(true) for colliding events and you don't need specific reset animation state function.
