### PR TITLE
Offset rbox by window scroll, because getBoundingClientRect changes when...

### DIFF
--- a/src/rbox.js
+++ b/src/rbox.js
@@ -46,6 +46,10 @@ SVG.RBox = function(element) {
   this.width  = box.width  /= zoom
   this.height = box.height /= zoom
   
+  /* offset by window scroll position, because getBoundingClientRect changes when window is scrolled */
+  this.x += window.scrollX;
+  this.y += window.scrollY;
+
   /* add center, right and bottom */
   boxProperties(this)
   


### PR DESCRIPTION
... window is scrolled

As per https://developer.mozilla.org/en-US/docs/Web/API/Element.getBoundingClientRect "If this is not the desired behaviour just add the current scrolling position to the top and left property (via window.scrollX and window.scrollY) to get constant values independent from the current scrolling position."
