### PR TITLE
Fixed event creation for IE

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -33,8 +33,17 @@ SVG.listeners = {}
 
 // Event constructor
 SVG.registerEvent = function(event) {
-  if (!SVG.events[event])
-    SVG.events[event] = new Event(event)
+  if (!SVG.events[event]) {
+    try {
+      SVG.events[event] = new Event(event)
+    }
+    catch(exception) {
+      // Fallback for IE that still uses createEvent/initEvent to create new events
+      var evtInstance = document.createEvent('Event')
+      evtInstance.initEvent(event, false, false)
+      SVG.events[event] = evtInstance
+    }
+  }
 }
 
 // Add event binder in the SVG namespace


### PR DESCRIPTION
Currently IE only supports the legacy way of creating events (ie. createEvent / initEvent), and will throw an exception if the new standards (using the Event constructor) are used. This patch catches this exception to try the legacy method if the new one does not work.
