### PR TITLE
Fix going down prototype chain

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -633,7 +633,7 @@ SVG.FX = SVG.invent({
 
         // get inital initialTransformation
         at = s.initialTransformation
-        for(i in s.transforms){
+        for(i = 0 ; i < s.transforms.length ; i++){
 
           // get next transformation in chain
           var a = s.transforms[i]


### PR DESCRIPTION
This fixed the a.undo is not a function error. The for loop was going down into  the array's prototype chain.