### PR TITLE
Format change log according to “Keep a CHANGELOG” guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,13 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed a bug in IE11 with `mouseenter` and `mouseleave` -> __TODO!__
 
 
-## 2.4.0 - 2017-01-14
+## [2.4.0] - 2017-01-14
 
 ### Added
 - added support for basic path animations (#561)
 
 
-## 2.3.7 - 2017-01-14
+## [2.3.7] - 2017-01-14
 
 ### Added
 - added code coverage https://coveralls.io/github/svgdotjs/svg.js (3e614d4)
@@ -46,7 +46,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed an error in `SVG.FX.step`, if custom properties is added to `Array.prototype` (#549)
 
 
-## 2.3.6 - 2016-10-21
+## [2.3.6] - 2016-10-21
 
 ### Changed
 - make SVG.FX.loop modify the last situation instead of the current one (#532)
@@ -57,7 +57,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed `SVG.FX.speed()` (#536)
 
 
-## 2.3.5 - 2016-10-13
+## [2.3.5] - 2016-10-13
 
 ### Added
 - added automated unit tests via [Travis](https://travis-ci.org/wout/svg.js) (#527)
@@ -69,14 +69,14 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - updated dependencies
 
 
-## 2.3.4 - 2016-08-04
+## [2.3.4] - 2016-08-04
 
 ### Changed
 - reworked parent module for speed improvemenents
 - reworked `filterSVGElements` utility to use a for loop instead of the native filter function
 
 
-## 2.3.3 - 2016-08-02
+## [2.3.3] - 2016-08-02
 
 ### Added
 - add error callback on image loading (#508)
@@ -86,7 +86,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed bug when getting bbox of element which is hidden with css (#516)
 
 
-## 2.3.2 - 2016-06-21
+## [2.3.2] - 2016-06-21
 
 ### Added
 - added specs for `SVG.ViewBox`
@@ -101,7 +101,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed `undo` when undoing transformations (#494)
 
 
-## 2.3.1 - 2016-05-05
+## [2.3.1] - 2016-05-05
 
 ### Added
 - added typings for svg.js (#470)
@@ -117,7 +117,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed bug in `parse()` from `SVG.PathArray` which does not correctly handled `S` and `T` (#485)
 
 
-## 2.3.0 - 2016-03-30
+## [2.3.0] - 2016-03-30
 
 ### Added
 - added `SVG.Point` which serves as Wrapper to the native `SVGPoint` (#437)
@@ -137,7 +137,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed event listeners which didnt work correctly when identic funtions used
 
 
-## 2.2.5 - 2015-12-29
+## [2.2.5] - 2015-12-29
 
 ### Added
 - added check for existence of node (#431)
@@ -147,7 +147,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - `matrixify()` will not apply the calculated matrix to the node anymore
 
 
-## 2.2.4 - 2015-12-12
+## [2.2.4] - 2015-12-12
 
 ### Fixed
 - fixed `transform()` which returns the matrix values (a-f) now, too (#423)
@@ -156,7 +156,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed target array in mask and clip which was removed instead of reinitialized (#429)
 
 
-## 2.2.3 - 2015-11-30
+## [2.2.3] - 2015-11-30
 
 ### Fixed
 - fixed null check in image (see 2.2.2)
@@ -164,7 +164,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed amd loader (#412)
 
 
-## 2.2.2 - 2015-11-28
+## [2.2.2] - 2015-11-28
 
 ### Added
 - added null check in image onload callback (#415)
@@ -176,7 +176,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed leading point bug in path parsing (#416)
 
 
-## 2.2.1 - 2015-11-18
+## [2.2.1] - 2015-11-18
 
 ### Added
 - added workaround for `SvgPathSeg` which is removed in Chrome 48 (#409)
@@ -186,7 +186,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed dom data which was not cleaned up properly (#398)
 
 
-## 2.2.0 - 2015-11-06
+## [2.2.0] - 2015-11-06
 
 ### Added
 - added `ungroup()/flatten()` (#238), `toParent()` and `toDoc()`
@@ -204,13 +204,13 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed return value of `text()` after import/clone (#393)
 
 
-## 2.1.1 - 2015-10-03
+## [2.1.1] - 2015-10-03
 
 ### Added
 - added custom context binding to event callback (default is the element the event is bound to)
 
 
-## 2.1.0 - 2015-09-20
+## [2.1.0] - 2015-09-20
 
 ### Added
 - added transform to pattern and gradients (#383)
@@ -222,13 +222,13 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed animate radius for circles (#367)
 
 
-## 2.0.2 - 2015-06-22
+## [2.0.2] - 2015-06-22
 
 ### Fixed
 - Fixed zoom consideration in circle and ellipse
 
 
-## 2.0.1 - 2015-06-21
+## [2.0.1] - 2015-06-21
 
 ### Added
 - added possibility to remove all events from a certain namespace
@@ -242,7 +242,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - removed scale consideration in `move()` duo to incompatibilities with other move-functions e.g. in `SVG.PointArray`
 
 
-## 2.0.0 - 2015-06-11
+## [2.0.0] - 2015-06-11
 
 ### Added
 - implemented an SVG adoption system to be able to manipulate existing SVG's not created with svg.js
@@ -290,7 +290,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed a bug where events are not detached properly
 
 
-## 1.0.0-rc.9 - 2014-06-17
+## [1.0.0-rc.9] - 2014-06-17
 
 ### Added
 - added `SVG.Marker`
@@ -306,14 +306,14 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed infinite loop in viewbox when element has a percentage width / height [thanks @shabegger]
 
 
-## 1.0.0-rc.8 - 2014-06-12
+## [1.0.0-rc.8] - 2014-06-12
 
 ### Fixed
 - fixed bug in `SVG.off`
 - fixed offset by window scroll position in `rbox()` [thanks @bryhoyt]
 
 
-## 1.0.0-rc.7 - 2014-06-11
+## [1.0.0-rc.7] - 2014-06-11
 
 ### Added
 - added `classes()`, `hasClass()`, `addClass()`, `removeClass()` and `toggleClass()` [thanks @pklingem]
@@ -331,7 +331,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fix in `style()` method with a css string [thanks @TobiasHeckel]
 
 
-## 1.0.0-rc.6 - 2014-03-03
+## [1.0.0-rc.6] - 2014-03-03
 
 ### Added
 - added `leading()` method to `SVG.FX`
@@ -352,7 +352,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - removed internal representation for `style`
 
 
-## 1.0.0-rc.5 - 2014-02-14
+## [1.0.0-rc.5] - 2014-02-14
 
 ### Added
 - added `plain()` method to `SVG.Text` element to add plain text content, without tspans
@@ -373,7 +373,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - removed verbose style application to tspans
 
 
-## 1.0.0-rc.4 - 2014-02-04
+## [1.0.0-rc.4] - 2014-02-04
 
 ### Added
 - automatic pattern creation by passing an image url or instance as `fill` attribute on elements
@@ -390,7 +390,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fix for arcs in patharray `toString()` method [thanks @dotnetCarpenter]
 
 
-## v1.0rc3 - 2014-02-03
+## [v1.0rc3] - 2014-02-03
 
 ### Added
 - added the `SVG.invent` function to ease invention of new elements
@@ -405,7 +405,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fix for arcs in patharray `toString()` method
 
 
-## v1.0rc2 - 2014-02-01
+## [v1.0rc2] - 2014-02-01
 
 ### Added
 - added `index()` method to `SVG.Parent` and `SVG.Set`
@@ -415,7 +415,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - modified `cx()` and `cy()` methods on elements with native `x`, `y`, `width` and `height` attributes for better performance
 
 
-## v1.0rc1 - 2014-01-31
+## [v1.0rc1] - 2014-01-31
 
 ### Added
 - added `SVG.PathArray` for real path transformations
@@ -432,7 +432,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - removed `unbiased` system for paths
 
 
-## v0.38 - 2014-01-28
+## [v0.38] - 2014-01-28
 
 ### Added
 - added `loop()` method to `SVG.FX`
@@ -441,7 +441,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - switched from `setInterval` to `requestAnimFrame` for animations
 
 
-## v0.37 - 2014-01-26
+## [v0.37] - 2014-01-26
 
 ### Added
 - added `get()` to `SVG.Set`
@@ -450,7 +450,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - moved `SVG.PointArray` to a separate file
 
 
-## v0.36 - 2014-01-25
+## [v0.36] - 2014-01-25
 
 ### Added
 - added `linkTo()`, `addTo()` and `putIn()` methods on `SVG.Element`
@@ -461,13 +461,13 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 ### Fixed
 
 
-## v0.35 - 2014-01-23
+## [v0.35] - 2014-01-23
 
 ### Added
 - added `SVG.A` element with the `link()`
 
 
-## v0.34 - 2014-01-23
+## [v0.34] - 2014-01-23
 
 ### Added
 - added `pause()` and `play()` to `SVG.FX`
@@ -476,7 +476,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - storing animation values in `situation` object
 
 
-## v0.33 - 2014-01-22
+## [v0.33] - 2014-01-22
 
 ### Added
 - added `has()` method to `SVG.Set`
@@ -490,8 +490,52 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - merged plotable.js and path.js
 
 
-## v0.32
+## [v0.32]
 
 ### Added
 - added library to [cdnjs](http://cdnjs.com)
 
+
+<!-- Headings above link to the releases listed here -->
+[2.4.0]: https://github.com/svgdotjs/svg.js/releases/tag/2.4.0
+
+[2.3.7]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.7
+[2.3.6]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.6
+[2.3.5]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.5
+[2.3.4]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.4
+[2.3.3]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.3
+[2.3.2]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.2
+[2.3.1]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.1
+[2.3.0]: https://github.com/svgdotjs/svg.js/releases/tag/2.3.0
+
+[2.2.5]: https://github.com/svgdotjs/svg.js/releases/tag/2.2.5
+[2.2.4]: https://github.com/svgdotjs/svg.js/releases/tag/2.2.4
+[2.2.3]: https://github.com/svgdotjs/svg.js/releases/tag/2.2.3
+[2.2.2]: https://github.com/svgdotjs/svg.js/releases/tag/2.2.2
+[2.2.1]: https://github.com/svgdotjs/svg.js/releases/tag/2.2.1
+[2.2.0]: https://github.com/svgdotjs/svg.js/releases/tag/2.2.0
+
+[2.1.1]: https://github.com/svgdotjs/svg.js/releases/tag/2.1.1
+[2.1.0]: https://github.com/svgdotjs/svg.js/releases/tag/2.1.0
+
+[2.0.2]: https://github.com/svgdotjs/svg.js/releases/tag/2.0.2
+[2.0.1]: https://github.com/svgdotjs/svg.js/releases/tag/2.0.1
+[2.0.0]: https://github.com/svgdotjs/svg.js/releases/tag/2.0.0
+
+[1.0.0-rc.9]: https://github.com/svgdotjs/svg.js/releases/tag/1.0.0-rc.9
+[1.0.0-rc.8]: https://github.com/svgdotjs/svg.js/releases/tag/1.0.0-rc.8
+[1.0.0-rc.7]: https://github.com/svgdotjs/svg.js/releases/tag/1.0.0-rc.7
+[1.0.0-rc.6]: https://github.com/svgdotjs/svg.js/releases/tag/1.0.0-rc.6
+[1.0.0-rc.5]: https://github.com/svgdotjs/svg.js/releases/tag/1.0.0-rc.5
+[1.0.0-rc.4]: https://github.com/svgdotjs/svg.js/releases/tag/1.0.0-rc.4
+[v1.0rc3]: https://github.com/svgdotjs/svg.js/releases/tag/v1.0rc3
+[v1.0rc2]: https://github.com/svgdotjs/svg.js/releases/tag/v1.0rc2
+[v1.0rc1]: https://github.com/svgdotjs/svg.js/releases/tag/v1.0rc1
+
+[v0.38]: https://github.com/svgdotjs/svg.js/releases/tag/v0.38
+[v0.37]: https://github.com/svgdotjs/svg.js/releases/tag/v0.37
+[v0.36]: https://github.com/svgdotjs/svg.js/releases/tag/v0.36
+[v0.35]: https://github.com/svgdotjs/svg.js/releases/tag/v0.35
+[v0.34]: https://github.com/svgdotjs/svg.js/releases/tag/v0.34
+[v0.33]: https://github.com/svgdotjs/svg.js/releases/tag/v0.33
+[v0.32]: https://github.com/svgdotjs/svg.js/releases/tag/v0.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The document follows the conventions described in [“Keep a CHANGELOG”](http://keepachangelog.com).
 
 
+====
 
-## 3.0.0
+
+## UNRELEASED 3.0.0
 
 ### Added
 - added `'random'` option and `randomize()` method to `SVG.Color` -> __TODO!__
@@ -20,6 +22,9 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 ### Fixed
 - fixed a bug in clipping and masking where empty nodes persists after removal -> __TODO!__
 - fixed a bug in IE11 with `mouseenter` and `mouseleave` -> __TODO!__
+
+
+====
 
 
 ## [2.4.0] - 2017-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# 3.0.0
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The document follows the conventions described in [“Keep a CHANGELOG”](http://keepachangelog.com).
+
+
+## 3.0.0
 - make transform-methods relative as default (breaking change)
 - change from SVG() to use querySelector instead of getElementById (breaking change)
 - added `'random'` option and `randomize()` method to `SVG.Color` -> __TODO!__
@@ -7,10 +14,10 @@
 - added `precision()` method to round numeric element attributes -> __TODO!__
 - added specs for `SVG.FX` -> __TODO!__
 
-# 2.4.0 - 2017-01-14
+## 2.4.0 - 2017-01-14
 - added support for basic path animations (#561)
 
-# 2.3.7 - 2017-01-14
+## 2.3.7 - 2017-01-14
 - moved project to [svgdotjs](https://github.com/svgdotjs)
 - made matrixify work with transformation chain separated by commas (#543)
 - fixed `SVG.Matrix.skew()` (#545)
@@ -21,29 +28,29 @@
 - added code coverage https://coveralls.io/github/svgdotjs/svg.js (3e614d4)
 - added `npm run test:quick` which aim at being fast rather than correct - great for git hooks (981ce24)
 
-# 2.3.6 - 2016-10-21
+## 2.3.6 - 2016-10-21
 - fixed leading and trailing space in SVG.PointArray would return NaN for some points (695f26a) (#529)
 - make SVG.FX.loop modify the last situation instead of the current one (#532)
 - fixed test of `SVG.FX.afterAll` (#534)
 - fixed `SVG.FX.speed()` (#536)
 
-# 2.3.5 - 2016-10-13
+## 2.3.5 - 2016-10-13
 - calling `fill()`, `stroke()` without an argument is now a nop
 - Polygon now accepts comma less points to achieve parity with Adobe Illustrator (#529)
 - added automated unit tests via [Travis](https://travis-ci.org/wout/svg.js) (#527)
 - updated dependencies
 - added `npm run build` to build a new version of SVG.js without requiring gulp to be globally installed
 
-# 2.3.4 - 2016-08-04
+## 2.3.4 - 2016-08-04
 - reworked parent module for speed improvemenents
 - reworked `filterSVGElements` utility to use a for loop instead of the native filter function
 
-# 2.3.3 - 2016-08-02
+## 2.3.3 - 2016-08-02
 - add error callback on image loading (#508)
 - fixed bug when getting bbox of text elements which are not in the dom (#514) 
 - fixed bug when getting bbox of element which is hidden with css (#516)
 
-# 2.3.2 - 2016-06-21
+## 2.3.2 - 2016-06-21
 - fixed string parsing in viewbox (#483)
 - added specs for `SVG.ViewBox`
 - fixed bbox when element is not in the dom (#480)
@@ -53,7 +60,7 @@
 - fixed problem in IE with `document.contains` (#490) related to (#480)
 - fixed `undo` when undoing transformations (#494)
 
-# 2.3.1 - 2016-05-05
+## 2.3.1 - 2016-05-05
 - fixed `SVG.morph()` (#473)
 - fixed parser error (#471)
 - fixed bug in `SVG.Color` with new fx
@@ -64,7 +71,7 @@
 - fixed bug in `SVG.Doc().create` where size was set to 100% even if size was already specified
 - fixed bug in `parse()` from `SVG.PathArray` which does not correctly handled `S` and `T` (#485)
 
-# 2.3.0 - 2016-03-30
+## 2.3.0 - 2016-03-30
 - added `SVG.Point` which serves as Wrapper to the native `SVGPoint` (#437)
 - added `element.point(x,y)` which transforms a point from screen coordinates to the elements space (#403)
 - fixed `svgjs:data` attribute which was not set properly in all browsers (#428)
@@ -77,33 +84,33 @@
 - added `element.is()` which helps to check for the object instance faster (instanceof check)
 - added more fx specs
 
-# 2.2.5 - 2015-12-29
+## 2.2.5 - 2015-12-29
 - added check for existence of node (#431)
 - `group.move()` now allows string numbers as input (#433)
 - `matrixify()` will not apply the calculated matrix to the node anymore
 
-# 2.2.4 - 2015-12-12
+## 2.2.4 - 2015-12-12
 - fixed `transform()` which returns the matrix values (a-f) now, too (#423)
 - double newlines (\n\n) are correctly handled as blank line from `text()`
 - fixed use of scrollX vs pageXOffset in `rbox()` (#425)
 - fixed target array in mask and clip which was removed instead of reinitialized (#429)
 
-# 2.2.3 - 2015-11-30
+## 2.2.3 - 2015-11-30
 - fixed null check in image (see 2.2.2)
 - fixed bug related to the new path parser (see 2.2.2)
 - fixed amd loader (#412)
 
-# 2.2.2 - 2015-11-28
+## 2.2.2 - 2015-11-28
 - fixed leading point bug in path parsing (#416)
 - added null check in image onload callback (#415)
 - documentation rework (#407) [thanks @snowyplover]
 
-# 2.2.1 - 2015-11-18
+## 2.2.1 - 2015-11-18
 - added workaround for `SvgPathSeg` which is removed in Chrome 48 (#409)
 - added `gbox()` to group to get bbox with translation included (#405)
 - fixed dom data which was not cleaned up properly (#398)
 
-# 2.2.0 - 2015-11-06
+## 2.2.0 - 2015-11-06
 
 - fixed pattern and gradient animation (#385)
 - fixed mask animation in Firefox (#287)
@@ -115,11 +122,11 @@
 - added support for css selectors within the `parent()` method
 - added `parents()` method to get an array of all parenting elements
 
-# 2.1.1 - 2015-10-03
+## 2.1.1 - 2015-10-03
 
 - added custom context binding to event callback (default is the element the event is bound to)
 
-# 2.1.0 - 2015-09-20
+## 2.1.0 - 2015-09-20
 
 - added transform to pattern and gradients (#383)
 - fixed clone of textnodes (#369)
@@ -127,11 +134,11 @@
 - fixed typo that leads to broken gradients (#370)
 - fixed animate radius for circles (#367)
 
-# 2.0.2 - 2015-06-22
+## 2.0.2 - 2015-06-22
 
 - Fixed zoom consideration in circle and ellipse
 
-# 2.0.1 - 2015-06-21
+## 2.0.1 - 2015-06-21
 
 - fixed bug with `doc()` which always should return root svg
 - removed target reference from use which caused bugs in `dmove()` and `use()` with external file
@@ -139,7 +146,7 @@
 - fixed bug in `SVG.FX` when animating with `plot()`
 - removed scale consideration in `move()` duo to incompatibilities with other move-functions e.g. in `SVG.PointArray`
 
-# 2.0.0 - 2015-06-11
+## 2.0.0 - 2015-06-11
 
 - implemented an SVG adoption system to be able to manipulate existing SVG's not created with svg.js
 - changed `parent` reference on elements to `parent()` method
@@ -181,7 +188,7 @@
 - fixed a bug where events are not detached properly
 - added event-based or complete detaching of event listeners in `off()` method
 
-# 1.0.0-rc.9 - 2014-06-17
+## 1.0.0-rc.9 - 2014-06-17
 
 - added `SVG.Marker`
 - added `SVG.Symbol`
@@ -191,12 +198,12 @@
 - added `reference()` method to get referenced elements from a given attribute value
 - fixed infinite loop in viewbox when element has a percentage width / height [thanks @shabegger]
 
-# 1.0.0-rc.8 - 2014-06-12
+## 1.0.0-rc.8 - 2014-06-12
 
 - fixed bug in `SVG.off`
 - fixed offset by window scroll position in `rbox()` [thanks @bryhoyt]
 
-# 1.0.0-rc.7 - 2014-06-11
+## 1.0.0-rc.7 - 2014-06-11
 
 - calling `after()` when calling `stop(true)` (fulfill flag) [thanks @vird]
 - added `classes()`, `hasClass()`, `addClass()`, `removeClass()` and `toggleClass()` [thanks @pklingem]
@@ -208,7 +215,7 @@
 - fix for `text()` method on text element when acting as getter [thanks @Lochemage]
 - fix in `style()` method with a css string [thanks @TobiasHeckel]
 
-# 1.0.0-rc.6 - 2014-03-03
+## 1.0.0-rc.6 - 2014-03-03
 
 - fine-tuned text element positioning
 - fixed a bug in text `dy()` method
@@ -221,7 +228,7 @@
 - moved helpers to a separate file
 - added more output values to `bbox()` and `rbox()` methods
 
-# 1.0.0-rc.5 - 2014-02-14
+## 1.0.0-rc.5 - 2014-02-14
 
 - added `plain()` method to `SVG.Text` element to add plain text content, without tspans
 - added `plain()` method to parent elements to create a text element without tspans
@@ -236,7 +243,7 @@
 - applied Helvetica as default font
 - building `SVG.FX` class with `SVG.invent()` function
 
-# 1.0.0-rc.4 - 2014-02-04
+## 1.0.0-rc.4 - 2014-02-04
 
 - switched to `MAJOR`.`MINOR`.`PATCH` versioning format to play nice with package managers
 - made svg.pattern.js part of the core library
@@ -247,7 +254,7 @@
 - moved `length()` method to sugar module
 - fix for arcs in patharray `toString()` method [thanks @dotnetCarpenter]
 
-# v1.0rc3 - 2014-02-03
+## v1.0rc3 - 2014-02-03
 
 - fix for html-less documents
 - added the `SVG.invent` function to ease invention of new elements
@@ -256,13 +263,13 @@
 - fix for arcs in patharray `toString()` method
 - added `length()` mehtod to path, wrapping the native `getTotalLength()`
 
-# v1.0rc2 - 2014-02-01
+## v1.0rc2 - 2014-02-01
 
 - added `index()` method to `SVG.Parent` and `SVG.Set`
 - modified `cx()` and `cy()` methods on elements with native `x`, `y`, `width` and `height` attributes for better performance
 - added `morph()` and `at()` methods to `SVG.Number` for unit morphing
 
-# v1.0rc1 - 2014-01-31
+## v1.0rc1 - 2014-01-31
 
 - added `SVG.PathArray` for real path transformations
 - removed `unbiased` system for paths
@@ -273,31 +280,31 @@
 - added `relative()` method for moves relative to the current position
 - added `morph()` and `at()` methods to `SVG.Color` for color morphing
 
-# v0.38 - 2014-01-28
+## v0.38 - 2014-01-28
 
 - added `loop()` method to `SVG.FX`
 - switched from `setInterval` to `requestAnimFrame` for animations
 
-# v0.37 - 2014-01-26
+## v0.37 - 2014-01-26
 
 - added `get()` to `SVG.Set`
 - moved `SVG.PointArray` to a separate file
 
-# v0.36 - 2014-01-25
+## v0.36 - 2014-01-25
 
 - added `linkTo()`, `addTo()` and `putIn()` methods on `SVG.Element`
 - provided more detailed documentation on parent elements
 
-# v0.35 - 2014-01-23
+## v0.35 - 2014-01-23
 
 - added `SVG.A` element with the `link()`
 
-# v0.34 - 2014-01-23
+## v0.34 - 2014-01-23
 
 - added `pause()` and `play()` to `SVG.FX`
 - storing animation values in `situation` object
 
-# v0.33 - 2014-01-22
+## v0.33 - 2014-01-22
 
 - added `has()` method to `SVG.Set`
 - added `width()` and `height()` as setter and getter methods on all shapes
@@ -307,6 +314,6 @@
 - added reference to parent node in defs
 - merged plotable.js and path.js
 
-# v0.32
+## v0.32
 
 - added library to [cdnjs](http://cdnjs.com)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The document follows the conventions described in [“Keep a CHANGELOG”](http://keepachangelog.com).
 
 
+
 ## 3.0.0
 - make transform-methods relative as default (breaking change)
 - change from SVG() to use querySelector instead of getElementById (breaking change)
@@ -14,8 +15,10 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added `precision()` method to round numeric element attributes -> __TODO!__
 - added specs for `SVG.FX` -> __TODO!__
 
+
 ## 2.4.0 - 2017-01-14
 - added support for basic path animations (#561)
+
 
 ## 2.3.7 - 2017-01-14
 - moved project to [svgdotjs](https://github.com/svgdotjs)
@@ -28,11 +31,13 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added code coverage https://coveralls.io/github/svgdotjs/svg.js (3e614d4)
 - added `npm run test:quick` which aim at being fast rather than correct - great for git hooks (981ce24)
 
+
 ## 2.3.6 - 2016-10-21
 - fixed leading and trailing space in SVG.PointArray would return NaN for some points (695f26a) (#529)
 - make SVG.FX.loop modify the last situation instead of the current one (#532)
 - fixed test of `SVG.FX.afterAll` (#534)
 - fixed `SVG.FX.speed()` (#536)
+
 
 ## 2.3.5 - 2016-10-13
 - calling `fill()`, `stroke()` without an argument is now a nop
@@ -41,14 +46,17 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - updated dependencies
 - added `npm run build` to build a new version of SVG.js without requiring gulp to be globally installed
 
+
 ## 2.3.4 - 2016-08-04
 - reworked parent module for speed improvemenents
 - reworked `filterSVGElements` utility to use a for loop instead of the native filter function
+
 
 ## 2.3.3 - 2016-08-02
 - add error callback on image loading (#508)
 - fixed bug when getting bbox of text elements which are not in the dom (#514) 
 - fixed bug when getting bbox of element which is hidden with css (#516)
+
 
 ## 2.3.2 - 2016-06-21
 - fixed string parsing in viewbox (#483)
@@ -60,6 +68,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed problem in IE with `document.contains` (#490) related to (#480)
 - fixed `undo` when undoing transformations (#494)
 
+
 ## 2.3.1 - 2016-05-05
 - fixed `SVG.morph()` (#473)
 - fixed parser error (#471)
@@ -70,6 +79,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed bug in `add()` when altering svgs with whitespaces
 - fixed bug in `SVG.Doc().create` where size was set to 100% even if size was already specified
 - fixed bug in `parse()` from `SVG.PathArray` which does not correctly handled `S` and `T` (#485)
+
 
 ## 2.3.0 - 2016-03-30
 - added `SVG.Point` which serves as Wrapper to the native `SVGPoint` (#437)
@@ -84,10 +94,12 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added `element.is()` which helps to check for the object instance faster (instanceof check)
 - added more fx specs
 
+
 ## 2.2.5 - 2015-12-29
 - added check for existence of node (#431)
 - `group.move()` now allows string numbers as input (#433)
 - `matrixify()` will not apply the calculated matrix to the node anymore
+
 
 ## 2.2.4 - 2015-12-12
 - fixed `transform()` which returns the matrix values (a-f) now, too (#423)
@@ -95,20 +107,24 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed use of scrollX vs pageXOffset in `rbox()` (#425)
 - fixed target array in mask and clip which was removed instead of reinitialized (#429)
 
+
 ## 2.2.3 - 2015-11-30
 - fixed null check in image (see 2.2.2)
 - fixed bug related to the new path parser (see 2.2.2)
 - fixed amd loader (#412)
+
 
 ## 2.2.2 - 2015-11-28
 - fixed leading point bug in path parsing (#416)
 - added null check in image onload callback (#415)
 - documentation rework (#407) [thanks @snowyplover]
 
+
 ## 2.2.1 - 2015-11-18
 - added workaround for `SvgPathSeg` which is removed in Chrome 48 (#409)
 - added `gbox()` to group to get bbox with translation included (#405)
 - fixed dom data which was not cleaned up properly (#398)
+
 
 ## 2.2.0 - 2015-11-06
 
@@ -122,9 +138,11 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added support for css selectors within the `parent()` method
 - added `parents()` method to get an array of all parenting elements
 
+
 ## 2.1.1 - 2015-10-03
 
 - added custom context binding to event callback (default is the element the event is bound to)
+
 
 ## 2.1.0 - 2015-09-20
 
@@ -134,9 +152,11 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed typo that leads to broken gradients (#370)
 - fixed animate radius for circles (#367)
 
+
 ## 2.0.2 - 2015-06-22
 
 - Fixed zoom consideration in circle and ellipse
+
 
 ## 2.0.1 - 2015-06-21
 
@@ -145,6 +165,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added possibility to remove all events from a certain namespace
 - fixed bug in `SVG.FX` when animating with `plot()`
 - removed scale consideration in `move()` duo to incompatibilities with other move-functions e.g. in `SVG.PointArray`
+
 
 ## 2.0.0 - 2015-06-11
 
@@ -188,6 +209,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fixed a bug where events are not detached properly
 - added event-based or complete detaching of event listeners in `off()` method
 
+
 ## 1.0.0-rc.9 - 2014-06-17
 
 - added `SVG.Marker`
@@ -198,10 +220,12 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added `reference()` method to get referenced elements from a given attribute value
 - fixed infinite loop in viewbox when element has a percentage width / height [thanks @shabegger]
 
+
 ## 1.0.0-rc.8 - 2014-06-12
 
 - fixed bug in `SVG.off`
 - fixed offset by window scroll position in `rbox()` [thanks @bryhoyt]
+
 
 ## 1.0.0-rc.7 - 2014-06-11
 
@@ -215,6 +239,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fix for `text()` method on text element when acting as getter [thanks @Lochemage]
 - fix in `style()` method with a css string [thanks @TobiasHeckel]
 
+
 ## 1.0.0-rc.6 - 2014-03-03
 
 - fine-tuned text element positioning
@@ -227,6 +252,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - moved most `_private` methods to local named functions
 - moved helpers to a separate file
 - added more output values to `bbox()` and `rbox()` methods
+
 
 ## 1.0.0-rc.5 - 2014-02-14
 
@@ -243,6 +269,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - applied Helvetica as default font
 - building `SVG.FX` class with `SVG.invent()` function
 
+
 ## 1.0.0-rc.4 - 2014-02-04
 
 - switched to `MAJOR`.`MINOR`.`PATCH` versioning format to play nice with package managers
@@ -254,6 +281,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - moved `length()` method to sugar module
 - fix for arcs in patharray `toString()` method [thanks @dotnetCarpenter]
 
+
 ## v1.0rc3 - 2014-02-03
 
 - fix for html-less documents
@@ -263,11 +291,13 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - fix for arcs in patharray `toString()` method
 - added `length()` mehtod to path, wrapping the native `getTotalLength()`
 
+
 ## v1.0rc2 - 2014-02-01
 
 - added `index()` method to `SVG.Parent` and `SVG.Set`
 - modified `cx()` and `cy()` methods on elements with native `x`, `y`, `width` and `height` attributes for better performance
 - added `morph()` and `at()` methods to `SVG.Number` for unit morphing
+
 
 ## v1.0rc1 - 2014-01-31
 
@@ -280,29 +310,35 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added `relative()` method for moves relative to the current position
 - added `morph()` and `at()` methods to `SVG.Color` for color morphing
 
+
 ## v0.38 - 2014-01-28
 
 - added `loop()` method to `SVG.FX`
 - switched from `setInterval` to `requestAnimFrame` for animations
+
 
 ## v0.37 - 2014-01-26
 
 - added `get()` to `SVG.Set`
 - moved `SVG.PointArray` to a separate file
 
+
 ## v0.36 - 2014-01-25
 
 - added `linkTo()`, `addTo()` and `putIn()` methods on `SVG.Element`
 - provided more detailed documentation on parent elements
 
+
 ## v0.35 - 2014-01-23
 
 - added `SVG.A` element with the `link()`
+
 
 ## v0.34 - 2014-01-23
 
 - added `pause()` and `play()` to `SVG.FX`
 - storing animation values in `situation` object
+
 
 ## v0.33 - 2014-01-22
 
@@ -313,6 +349,7 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 - added `radius()` method to `SVG.Rect` and `SVG.Ellipse`
 - added reference to parent node in defs
 - merged plotable.js and path.js
+
 
 ## v0.32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 - added `precision()` method to round numeric element attributes -> __TODO!__
 - added specs for `SVG.FX` -> __TODO!__
 
-# 2.4.0 (14/01/2017)
+# 2.4.0 - 2017-01-14
 - added support for basic path animations (#561)
 
-# 2.3.7 (14/01/2017)
+# 2.3.7 - 2017-01-14
 - moved project to [svgdotjs](https://github.com/svgdotjs)
 - made matrixify work with transformation chain separated by commas (#543)
 - fixed `SVG.Matrix.skew()` (#545)
@@ -21,29 +21,29 @@
 - added code coverage https://coveralls.io/github/svgdotjs/svg.js (3e614d4)
 - added `npm run test:quick` which aim at being fast rather than correct - great for git hooks (981ce24)
 
-# 2.3.6 (21/10/2016)
+# 2.3.6 - 2016-10-21
 - fixed leading and trailing space in SVG.PointArray would return NaN for some points (695f26a) (#529)
 - make SVG.FX.loop modify the last situation instead of the current one (#532)
 - fixed test of `SVG.FX.afterAll` (#534)
 - fixed `SVG.FX.speed()` (#536)
 
-# 2.3.5 (13/10/2016)
+# 2.3.5 - 2016-10-13
 - calling `fill()`, `stroke()` without an argument is now a nop
 - Polygon now accepts comma less points to achieve parity with Adobe Illustrator (#529)
 - added automated unit tests via [Travis](https://travis-ci.org/wout/svg.js) (#527)
 - updated dependencies
 - added `npm run build` to build a new version of SVG.js without requiring gulp to be globally installed
 
-# 2.3.4 (04/08/2016)
+# 2.3.4 - 2016-08-04
 - reworked parent module for speed improvemenents
 - reworked `filterSVGElements` utility to use a for loop instead of the native filter function
 
-# 2.3.3 (02/08/2016)
+# 2.3.3 - 2016-08-02
 - add error callback on image loading (#508)
 - fixed bug when getting bbox of text elements which are not in the dom (#514) 
 - fixed bug when getting bbox of element which is hidden with css (#516)
 
-# 2.3.2 (21/06/2016)
+# 2.3.2 - 2016-06-21
 - fixed string parsing in viewbox (#483)
 - added specs for `SVG.ViewBox`
 - fixed bbox when element is not in the dom (#480)
@@ -53,7 +53,7 @@
 - fixed problem in IE with `document.contains` (#490) related to (#480)
 - fixed `undo` when undoing transformations (#494)
 
-# 2.3.1 (05/05/2016)
+# 2.3.1 - 2016-05-05
 - fixed `SVG.morph()` (#473)
 - fixed parser error (#471)
 - fixed bug in `SVG.Color` with new fx
@@ -64,7 +64,7 @@
 - fixed bug in `SVG.Doc().create` where size was set to 100% even if size was already specified
 - fixed bug in `parse()` from `SVG.PathArray` which does not correctly handled `S` and `T` (#485)
 
-# 2.3.0 (30/03/2016)
+# 2.3.0 - 2016-03-30
 - added `SVG.Point` which serves as Wrapper to the native `SVGPoint` (#437)
 - added `element.point(x,y)` which transforms a point from screen coordinates to the elements space (#403)
 - fixed `svgjs:data` attribute which was not set properly in all browsers (#428)
@@ -77,33 +77,33 @@
 - added `element.is()` which helps to check for the object instance faster (instanceof check)
 - added more fx specs
 
-# 2.2.5 (29/12/2015)
+# 2.2.5 - 2015-12-29
 - added check for existence of node (#431)
 - `group.move()` now allows string numbers as input (#433)
 - `matrixify()` will not apply the calculated matrix to the node anymore
 
-# 2.2.4 (12/12/2015)
+# 2.2.4 - 2015-12-12
 - fixed `transform()` which returns the matrix values (a-f) now, too (#423)
 - double newlines (\n\n) are correctly handled as blank line from `text()`
 - fixed use of scrollX vs pageXOffset in `rbox()` (#425)
 - fixed target array in mask and clip which was removed instead of reinitialized (#429)
 
-# 2.2.3 (30/11/2015)
+# 2.2.3 - 2015-11-30
 - fixed null check in image (see 2.2.2)
 - fixed bug related to the new path parser (see 2.2.2)
 - fixed amd loader (#412)
 
-# 2.2.2 (28/11/2015)
+# 2.2.2 - 2015-11-28
 - fixed leading point bug in path parsing (#416)
 - added null check in image onload callback (#415)
 - documentation rework (#407) [thanks @snowyplover]
 
-# 2.2.1 (18/11/2015)
+# 2.2.1 - 2015-11-18
 - added workaround for `SvgPathSeg` which is removed in Chrome 48 (#409)
 - added `gbox()` to group to get bbox with translation included (#405)
 - fixed dom data which was not cleaned up properly (#398)
 
-# 2.2.0 (06/11/2015)
+# 2.2.0 - 2015-11-06
 
 - fixed pattern and gradient animation (#385)
 - fixed mask animation in Firefox (#287)
@@ -115,11 +115,11 @@
 - added support for css selectors within the `parent()` method
 - added `parents()` method to get an array of all parenting elements
 
-# 2.1.1 (03/10/2015)
+# 2.1.1 - 2015-10-03
 
 - added custom context binding to event callback (default is the element the event is bound to)
 
-# 2.1.0 (20/09/2015)
+# 2.1.0 - 2015-09-20
 
 - added transform to pattern and gradients (#383)
 - fixed clone of textnodes (#369)
@@ -127,11 +127,11 @@
 - fixed typo that leads to broken gradients (#370)
 - fixed animate radius for circles (#367)
 
-# 2.0.2 (22/06/2015)
+# 2.0.2 - 2015-06-22
 
 - Fixed zoom consideration in circle and ellipse
 
-# 2.0.1 (21/06/2015)
+# 2.0.1 - 2015-06-21
 
 - fixed bug with `doc()` which always should return root svg
 - removed target reference from use which caused bugs in `dmove()` and `use()` with external file
@@ -139,7 +139,7 @@
 - fixed bug in `SVG.FX` when animating with `plot()`
 - removed scale consideration in `move()` duo to incompatibilities with other move-functions e.g. in `SVG.PointArray`
 
-# 2.0.0 (11/06/2015)
+# 2.0.0 - 2015-06-11
 
 - implemented an SVG adoption system to be able to manipulate existing SVG's not created with svg.js
 - changed `parent` reference on elements to `parent()` method
@@ -181,7 +181,7 @@
 - fixed a bug where events are not detached properly
 - added event-based or complete detaching of event listeners in `off()` method
 
-# 1.0.0-rc.9 (17/06/2014)
+# 1.0.0-rc.9 - 2014-06-17
 
 - added `SVG.Marker`
 - added `SVG.Symbol`
@@ -191,12 +191,12 @@
 - added `reference()` method to get referenced elements from a given attribute value
 - fixed infinite loop in viewbox when element has a percentage width / height [thanks @shabegger]
 
-# 1.0.0-rc.8 (12/06/2014)
+# 1.0.0-rc.8 - 2014-06-12
 
 - fixed bug in `SVG.off`
 - fixed offset by window scroll position in `rbox()` [thanks @bryhoyt]
 
-# 1.0.0-rc.7 (11/06/2014)
+# 1.0.0-rc.7 - 2014-06-11
 
 - calling `after()` when calling `stop(true)` (fulfill flag) [thanks @vird]
 - added `classes()`, `hasClass()`, `addClass()`, `removeClass()` and `toggleClass()` [thanks @pklingem]
@@ -208,7 +208,7 @@
 - fix for `text()` method on text element when acting as getter [thanks @Lochemage]
 - fix in `style()` method with a css string [thanks @TobiasHeckel]
 
-# 1.0.0-rc.6 (03/03/2014)
+# 1.0.0-rc.6 - 2014-03-03
 
 - fine-tuned text element positioning
 - fixed a bug in text `dy()` method
@@ -221,7 +221,7 @@
 - moved helpers to a separate file
 - added more output values to `bbox()` and `rbox()` methods
 
-# 1.0.0-rc.5 (14/02/2014)
+# 1.0.0-rc.5 - 2014-02-14
 
 - added `plain()` method to `SVG.Text` element to add plain text content, without tspans
 - added `plain()` method to parent elements to create a text element without tspans
@@ -236,7 +236,7 @@
 - applied Helvetica as default font
 - building `SVG.FX` class with `SVG.invent()` function
 
-# 1.0.0-rc.4 (04/02/2014)
+# 1.0.0-rc.4 - 2014-02-04
 
 - switched to `MAJOR`.`MINOR`.`PATCH` versioning format to play nice with package managers
 - made svg.pattern.js part of the core library
@@ -247,7 +247,7 @@
 - moved `length()` method to sugar module
 - fix for arcs in patharray `toString()` method [thanks @dotnetCarpenter]
 
-# v1.0rc3 (03/02/2014)
+# v1.0rc3 - 2014-02-03
 
 - fix for html-less documents
 - added the `SVG.invent` function to ease invention of new elements
@@ -256,13 +256,13 @@
 - fix for arcs in patharray `toString()` method
 - added `length()` mehtod to path, wrapping the native `getTotalLength()`
 
-# v1.0rc2 (01/02/2014)
+# v1.0rc2 - 2014-02-01
 
 - added `index()` method to `SVG.Parent` and `SVG.Set`
 - modified `cx()` and `cy()` methods on elements with native `x`, `y`, `width` and `height` attributes for better performance
 - added `morph()` and `at()` methods to `SVG.Number` for unit morphing
 
-# v1.0rc1 (31/01/2014)
+# v1.0rc1 - 2014-01-31
 
 - added `SVG.PathArray` for real path transformations
 - removed `unbiased` system for paths
@@ -273,31 +273,31 @@
 - added `relative()` method for moves relative to the current position
 - added `morph()` and `at()` methods to `SVG.Color` for color morphing
 
-# v0.38 (28/01/2014)
+# v0.38 - 2014-01-28
 
 - added `loop()` method to `SVG.FX`
 - switched from `setInterval` to `requestAnimFrame` for animations
 
-# v0.37 (26/01/2014)
+# v0.37 - 2014-01-26
 
 - added `get()` to `SVG.Set`
 - moved `SVG.PointArray` to a separate file
 
-# v0.36 (25/01/2014)
+# v0.36 - 2014-01-25
 
 - added `linkTo()`, `addTo()` and `putIn()` methods on `SVG.Element`
 - provided more detailed documentation on parent elements
 
-# v0.35 (23/01/2014)
+# v0.35 - 2014-01-23
 
 - added `SVG.A` element with the `link()`
 
-# v0.34 (23/01/2014)
+# v0.34 - 2014-01-23
 
 - added `pause()` and `play()` to `SVG.FX`
 - storing animation values in `situation` object
 
-# v0.33 (22/01/2014)
+# v0.33 - 2014-01-22
 
 - added `has()` method to `SVG.Set`
 - added `width()` and `height()` as setter and getter methods on all shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,101 +7,149 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 
 
 ## 3.0.0
-- make transform-methods relative as default (breaking change)
-- change from SVG() to use querySelector instead of getElementById (breaking change)
+
+### Added
 - added `'random'` option and `randomize()` method to `SVG.Color` -> __TODO!__
-- fixed a bug in clipping and masking where empty nodes persists after removal -> __TODO!__
-- fixed a bug in IE11 with `mouseenter` and `mouseleave` -> __TODO!__
 - added `precision()` method to round numeric element attributes -> __TODO!__
 - added specs for `SVG.FX` -> __TODO!__
 
+### Changed
+- make transform-methods relative as default (breaking change)
+- change from SVG() to use querySelector instead of getElementById (breaking change)
+
+### Fixed
+- fixed a bug in clipping and masking where empty nodes persists after removal -> __TODO!__
+- fixed a bug in IE11 with `mouseenter` and `mouseleave` -> __TODO!__
+
 
 ## 2.4.0 - 2017-01-14
+
+### Added
 - added support for basic path animations (#561)
 
 
 ## 2.3.7 - 2017-01-14
+
+### Added
+- added code coverage https://coveralls.io/github/svgdotjs/svg.js (3e614d4)
+- added `npm run test:quick` which aim at being fast rather than correct - great for git hooks (981ce24)
+
+### Changed
 - moved project to [svgdotjs](https://github.com/svgdotjs)
 - made matrixify work with transformation chain separated by commas (#543)
+- updated dev dependencies; request and gulp-chmod - `npm run build` now requires nodejs 4.x
+
+### Fixed
 - fixed `SVG.Matrix.skew()` (#545)
 - fixed broken animations, if using polyfills for es6/7 proposals (#504)
 - fixed and improved `SVG.FX.dequeue()` (#546)
 - fixed an error in `SVG.FX.step`, if custom properties is added to `Array.prototype` (#549)
-- updated dev dependencies; request and gulp-chmod - `npm run build` now requires nodejs 4.x
-- added code coverage https://coveralls.io/github/svgdotjs/svg.js (3e614d4)
-- added `npm run test:quick` which aim at being fast rather than correct - great for git hooks (981ce24)
 
 
 ## 2.3.6 - 2016-10-21
-- fixed leading and trailing space in SVG.PointArray would return NaN for some points (695f26a) (#529)
+
+### Changed
 - make SVG.FX.loop modify the last situation instead of the current one (#532)
+
+### Fixed
+- fixed leading and trailing space in SVG.PointArray would return NaN for some points (695f26a) (#529)
 - fixed test of `SVG.FX.afterAll` (#534)
 - fixed `SVG.FX.speed()` (#536)
 
 
 ## 2.3.5 - 2016-10-13
+
+### Added
+- added automated unit tests via [Travis](https://travis-ci.org/wout/svg.js) (#527)
+- added `npm run build` to build a new version of SVG.js without requiring gulp to be globally installed
+
+### Changed
 - calling `fill()`, `stroke()` without an argument is now a nop
 - Polygon now accepts comma less points to achieve parity with Adobe Illustrator (#529)
-- added automated unit tests via [Travis](https://travis-ci.org/wout/svg.js) (#527)
 - updated dependencies
-- added `npm run build` to build a new version of SVG.js without requiring gulp to be globally installed
 
 
 ## 2.3.4 - 2016-08-04
+
+### Changed
 - reworked parent module for speed improvemenents
 - reworked `filterSVGElements` utility to use a for loop instead of the native filter function
 
 
 ## 2.3.3 - 2016-08-02
+
+### Added
 - add error callback on image loading (#508)
+
+### Fixed
 - fixed bug when getting bbox of text elements which are not in the dom (#514) 
 - fixed bug when getting bbox of element which is hidden with css (#516)
 
 
 ## 2.3.2 - 2016-06-21
-- fixed string parsing in viewbox (#483)
+
+### Added
 - added specs for `SVG.ViewBox`
-- fixed bbox when element is not in the dom (#480)
 - added `parent` parameter for `clone()`
-- fixed line constructor which doesn't work with Array as input (#487)
 - added spec for mentioned issue
+
+### Fixed
+- fixed string parsing in viewbox (#483)
+- fixed bbox when element is not in the dom (#480)
+- fixed line constructor which doesn't work with Array as input (#487)
 - fixed problem in IE with `document.contains` (#490) related to (#480)
 - fixed `undo` when undoing transformations (#494)
 
 
 ## 2.3.1 - 2016-05-05
+
+### Added
+- added typings for svg.js (#470)
+
+### Fixed
 - fixed `SVG.morph()` (#473)
 - fixed parser error (#471)
 - fixed bug in `SVG.Color` with new fx
 - fixed `radius()` for circles when animating and other related code (#477)
 - fixed bug where `stop(true)` throws an error when element is not animated (#475)
-- added typings for svg.js (#470)
 - fixed bug in `add()` when altering svgs with whitespaces
 - fixed bug in `SVG.Doc().create` where size was set to 100% even if size was already specified
 - fixed bug in `parse()` from `SVG.PathArray` which does not correctly handled `S` and `T` (#485)
 
 
 ## 2.3.0 - 2016-03-30
+
+### Added
 - added `SVG.Point` which serves as Wrapper to the native `SVGPoint` (#437)
 - added `element.point(x,y)` which transforms a point from screen coordinates to the elements space (#403)
-- fixed `svgjs:data` attribute which was not set properly in all browsers (#428)
-- fixed `isNumber` and `numberAndUnit` regex (#405)
-- fixed error where a parent node is not found when loading an image but the canvas was cleared (#447)
-- textpath now is a parent element, the lines method of text will return the tspans inside the textpath (#450)
-- fx module rewritten to support animation chaining and several other stuff (see docs)
-- fixed absolute transformation animations (not perfect but better)
-- fixed event listeners which didnt work correctly when identic funtions used
 - added `element.is()` which helps to check for the object instance faster (instanceof check)
 - added more fx specs
 
+### Changed
+- textpath now is a parent element, the lines method of text will return the tspans inside the textpath (#450)
+- fx module rewritten to support animation chaining and several other stuff (see docs)
+
+### Fixed
+- fixed `svgjs:data` attribute which was not set properly in all browsers (#428)
+- fixed `isNumber` and `numberAndUnit` regex (#405)
+- fixed error where a parent node is not found when loading an image but the canvas was cleared (#447)
+- fixed absolute transformation animations (not perfect but better)
+- fixed event listeners which didnt work correctly when identic funtions used
+
 
 ## 2.2.5 - 2015-12-29
+
+### Added
 - added check for existence of node (#431)
+
+### Changed
 - `group.move()` now allows string numbers as input (#433)
 - `matrixify()` will not apply the calculated matrix to the node anymore
 
 
 ## 2.2.4 - 2015-12-12
+
+### Fixed
 - fixed `transform()` which returns the matrix values (a-f) now, too (#423)
 - double newlines (\n\n) are correctly handled as blank line from `text()`
 - fixed use of scrollX vs pageXOffset in `rbox()` (#425)
@@ -109,44 +157,65 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 
 
 ## 2.2.3 - 2015-11-30
+
+### Fixed
 - fixed null check in image (see 2.2.2)
 - fixed bug related to the new path parser (see 2.2.2)
 - fixed amd loader (#412)
 
 
 ## 2.2.2 - 2015-11-28
-- fixed leading point bug in path parsing (#416)
+
+### Added
 - added null check in image onload callback (#415)
+
+### Changed
 - documentation rework (#407) [thanks @snowyplover]
+
+### Fixed
+- fixed leading point bug in path parsing (#416)
 
 
 ## 2.2.1 - 2015-11-18
+
+### Added
 - added workaround for `SvgPathSeg` which is removed in Chrome 48 (#409)
 - added `gbox()` to group to get bbox with translation included (#405)
+
+### Fixed
 - fixed dom data which was not cleaned up properly (#398)
 
 
 ## 2.2.0 - 2015-11-06
 
-- fixed pattern and gradient animation (#385)
-- fixed mask animation in Firefox (#287)
-- fixed return value of `text()` after import/clone (#393)
-- svgjs now saves crucial data in the dom before export and restores them when element is adopted
+### Added
 - added `ungroup()/flatten()` (#238), `toParent()` and `toDoc()`
 - added UMD-Wrapper with possibility to pass custom window object (#352)
 - added `morph()` method for paths via plugin [svg.pathmorphing.js](https://github.com/Fuzzyma/svg.pathmorphing.js)
 - added support for css selectors within the `parent()` method
 - added `parents()` method to get an array of all parenting elements
 
+### Changed
+- svgjs now saves crucial data in the dom before export and restores them when element is adopted
+
+### Fixed
+- fixed pattern and gradient animation (#385)
+- fixed mask animation in Firefox (#287)
+- fixed return value of `text()` after import/clone (#393)
+
 
 ## 2.1.1 - 2015-10-03
 
+### Added
 - added custom context binding to event callback (default is the element the event is bound to)
 
 
 ## 2.1.0 - 2015-09-20
 
+### Added
 - added transform to pattern and gradients (#383)
+
+### Fixed
 - fixed clone of textnodes (#369)
 - fixed transformlists in IE (#372)
 - fixed typo that leads to broken gradients (#370)
@@ -155,202 +224,274 @@ The document follows the conventions described in [“Keep a CHANGELOG”](http:
 
 ## 2.0.2 - 2015-06-22
 
+### Fixed
 - Fixed zoom consideration in circle and ellipse
 
 
 ## 2.0.1 - 2015-06-21
 
-- fixed bug with `doc()` which always should return root svg
-- removed target reference from use which caused bugs in `dmove()` and `use()` with external file
+### Added
 - added possibility to remove all events from a certain namespace
+
+### Fixed
+- fixed bug with `doc()` which always should return root svg
 - fixed bug in `SVG.FX` when animating with `plot()`
+
+### Removed
+- removed target reference from use which caused bugs in `dmove()` and `use()` with external file
 - removed scale consideration in `move()` duo to incompatibilities with other move-functions e.g. in `SVG.PointArray`
 
 
 ## 2.0.0 - 2015-06-11
 
+### Added
 - implemented an SVG adoption system to be able to manipulate existing SVG's not created with svg.js
-- changed `parent` reference on elements to `parent()` method
-- using `CustomEvent` instead of `Event` to be able to fire events with a `detail` object [thanks @Fuzzyma]
 - added polyfill for IE9 and IE10 custom events [thanks @Fuzzyma]
 - added DOM query selector with the `select()` method globally or on parent elements
 - added the intentionally neglected `SVG.Circle` element
-- fixed bug in `radius()` method when `y` value equals `0`
-- renamed `SVG.TSpan` class to `SVG.Tspan` to play nice with the adoption system
 - added `rx()` and `ry()` to `SVG.Rect`, `SVG.Circle`, `SVG.Ellispe` and `SVG.FX`
-- changed `array` reference to `array()` method on `SVG.Polyline`, `SVG.Polygon` and `SVG.Path`
-- completely reworked `clone()` method to use the adoption system
 - added support to clone manually built text elements
 - added `svg.wiml.js` plugin to plugins list
 - added `ctm()` method to for matrix-centric transformations
 - added `morph()` method to `SVG.Matrix`
 - added support for new matrix system to `SVG.FX`
+- added `native()` method to elements and matrix to get to the native api
+- added `untransform()` method to remove all transformations
+- added raw svg import functionality with the `svg()` method
+- added coding style description to README
+- added reverse functionality for animations
+- documented the `situation` object in `SVG.FX`
+- added distinction between relative and absolute matrix transformations
+- implemented the `element()` method using the `SVG.Bare` class to create elements that are not described by SVG.js
+- added `w` and `h` properties as shorthand for `width` and `height` to `SVG.BBox`
+- added `SVG.TBox` to get a bounding box that is affected by transformation values
+- added event-based or complete detaching of event listeners in `off()` method
+
+### Changed
+- changed `parent` reference on elements to `parent()` method
+- using `CustomEvent` instead of `Event` to be able to fire events with a `detail` object [thanks @Fuzzyma]
+- renamed `SVG.TSpan` class to `SVG.Tspan` to play nice with the adoption system
+- completely reworked `clone()` method to use the adoption system
 - completely reworked transformations to be chainable and more true to their nature
 - changed `lines` reference to `lines()` on `SVG.Text`
 - changed `track` reference to `track()` on `SVG.Text`
 - changed `textPath` reference to `textPath()` on `SVG.Text`
-- added raw svg import functionality with the `svg()` method
+- changed `array` reference to `array()` method on `SVG.Polyline`, `SVG.Polygon` and `SVG.Path`
 - reworked sup-pixel offset implementation to be more compact
-- added `native()` method to elements and matrix to get to the native api
-- added `untransform()` method to remove all transformations
 - switched from Ruby's `rake` to Node's `gulp` for building [thanks to Alex Ewerlöf]
-- added coding style description to README
 - changed `to()` method to `at()` method in `SVG.FX`
-- added reverse functionality for animations
-- documented the `situation` object in `SVG.FX`
 - renamed `SVG.SetFX` to `SVG.FX.Set`
-- added distinction between relative and absolute matrix transformations
-- implemented the `element()` method using the `SVG.Bare` class to create elements that are not described by SVG.js
-- removed `SVG.Symbol` but kept the `symbol()` method using the new `element()` method
 - reworked `SVG.Number` to return new instances with calculations rather than itself
-- added `w` and `h` properties as shorthand for `width` and `height` to `SVG.BBox`
-- added `SVG.TBox` to get a bounding box that is affected by transformation values
 - reworked animatable matrix rotations
+- removed `SVG.Symbol` but kept the `symbol()` method using the new `element()` method
+
+### Fixed
+- fixed bug in `radius()` method when `y` value equals `0`
 - fixed a bug where events are not detached properly
-- added event-based or complete detaching of event listeners in `off()` method
 
 
 ## 1.0.0-rc.9 - 2014-06-17
 
+### Added
 - added `SVG.Marker`
 - added `SVG.Symbol`
 - added `first()` and `last()` methods to `SVG.Set`
 - added `length()` method to `SVG.Text` and `SVG.TSpan` to calculate total text length
-- `SVG.get()` will now also fetch elements with a `xlink:href="#elementId"` or `url(#elementId)` value given
 - added `reference()` method to get referenced elements from a given attribute value
+
+### Changed
+- `SVG.get()` will now also fetch elements with a `xlink:href="#elementId"` or `url(#elementId)` value given
+
+### Fixed
 - fixed infinite loop in viewbox when element has a percentage width / height [thanks @shabegger]
 
 
 ## 1.0.0-rc.8 - 2014-06-12
 
+### Fixed
 - fixed bug in `SVG.off`
 - fixed offset by window scroll position in `rbox()` [thanks @bryhoyt]
 
 
 ## 1.0.0-rc.7 - 2014-06-11
 
-- calling `after()` when calling `stop(true)` (fulfill flag) [thanks @vird]
+### Added
 - added `classes()`, `hasClass()`, `addClass()`, `removeClass()` and `toggleClass()` [thanks @pklingem]
+
+### Changed
+- binding events listeners to svg.js instance
+- calling `after()` when calling `stop(true)` (fulfill flag) [thanks @vird]
+- text element fires `rebuild` event whenever the `rebuild()` method is called
+
+### Fixed
 - fixed a bug where `Element#style()` would not save empty values in IE11 [thanks @Shtong]
 - fixed `SVG is not defined error` [thanks @anvaka]
 - fixed a bug in `move()`on text elements with a string based value
-- binding events listeners to svg.js instance
-- text element fires `rebuild` event whenever the `rebuild()` method is called
 - fix for `text()` method on text element when acting as getter [thanks @Lochemage]
 - fix in `style()` method with a css string [thanks @TobiasHeckel]
 
 
 ## 1.0.0-rc.6 - 2014-03-03
 
-- fine-tuned text element positioning
-- fixed a bug in text `dy()` method
+### Added
 - added `leading()` method to `SVG.FX`
-- removed internal representation for `style`
 - added `reverse()` method to `SVG.Array` (and thereby also to `SVG.PointArray` and `SVG.PathArray`)
 - added `fulfill` option to `stop()` method in `SVG.FX` to finalise animations
+- added more output values to `bbox()` and `rbox()` methods
+
+### Changed
+- fine-tuned text element positioning
 - calling `at()` method directly on morphable svg.js instances in `SVG.FX` module
 - moved most `_private` methods to local named functions
 - moved helpers to a separate file
-- added more output values to `bbox()` and `rbox()` methods
+
+### Fixed
+- fixed a bug in text `dy()` method
+
+### Removed
+- removed internal representation for `style`
 
 
 ## 1.0.0-rc.5 - 2014-02-14
 
+### Added
 - added `plain()` method to `SVG.Text` element to add plain text content, without tspans
 - added `plain()` method to parent elements to create a text element without tspans
+- added `build()` to enable/disable build mode
+
+### Changed
 - updated `SVG.TSpan` to accept nested tspan elements, not unlike the `text()` method in `SVG.Text`
 - removed the `relative()` method in favour of `dx()`, `dy()` and `dmove()`
 - switched form objects to arrays in `SVG.PathArray` for compatibility with other libraries and better performance on parsing and rendering (up-to 48% faster than 1.0.0-rc.4)
 - refined docs on element-specific methods and `SVG.PathArray` structure
-- added `build()` to enable/disable build mode
-- removed verbose style application to tspans
 - reworked `leading()` implementation to be more font-size "aware"
 - refactored the `attr` method on `SVG.Element`
 - applied Helvetica as default font
 - building `SVG.FX` class with `SVG.invent()` function
 
+### Removed
+- removed verbose style application to tspans
+
 
 ## 1.0.0-rc.4 - 2014-02-04
 
-- switched to `MAJOR`.`MINOR`.`PATCH` versioning format to play nice with package managers
-- made svg.pattern.js part of the core library
+### Added
 - automatic pattern creation by passing an image url or instance as `fill` attribute on elements
 - added `loaded()` method to image tag
-- fix in `animate('=').to()`
 - added `pointAt()` method to `SVG.Path`, wrapping the native `getPointAtLength()`
+
+### Changed
+- switched to `MAJOR`.`MINOR`.`PATCH` versioning format to play nice with package managers
+- made svg.pattern.js part of the core library
 - moved `length()` method to sugar module
+
+### Fixed
+- fix in `animate('=').to()`
 - fix for arcs in patharray `toString()` method [thanks @dotnetCarpenter]
 
 
 ## v1.0rc3 - 2014-02-03
 
-- fix for html-less documents
+### Added
 - added the `SVG.invent` function to ease invention of new elements
-- using `SVG.invent` to generate core shapes as well for leaner code
 - added second values for `animate('2s')`
-- fix for arcs in patharray `toString()` method
 - added `length()` mehtod to path, wrapping the native `getTotalLength()`
+
+### Changed
+- using `SVG.invent` to generate core shapes as well for leaner code
+
+### Fixed
+- fix for html-less documents
+- fix for arcs in patharray `toString()` method
 
 
 ## v1.0rc2 - 2014-02-01
 
+### Added
 - added `index()` method to `SVG.Parent` and `SVG.Set`
-- modified `cx()` and `cy()` methods on elements with native `x`, `y`, `width` and `height` attributes for better performance
 - added `morph()` and `at()` methods to `SVG.Number` for unit morphing
+
+### Changed
+- modified `cx()` and `cy()` methods on elements with native `x`, `y`, `width` and `height` attributes for better performance
 
 
 ## v1.0rc1 - 2014-01-31
 
+### Added
 - added `SVG.PathArray` for real path transformations
-- removed `unbiased` system for paths
-- enabled proportional resizing on `size()` method with `null` for either `width` or `height` values
-- moved data module to separate file
-- `data()` method now accepts object for for multiple key / value assignments
 - added `bbox()` method to `SVG.Set`
 - added `relative()` method for moves relative to the current position
 - added `morph()` and `at()` methods to `SVG.Color` for color morphing
 
+### Changed
+- enabled proportional resizing on `size()` method with `null` for either `width` or `height` values
+- moved data module to separate file
+- `data()` method now accepts object for for multiple key / value assignments
+
+### Removed
+- removed `unbiased` system for paths
+
 
 ## v0.38 - 2014-01-28
 
+### Added
 - added `loop()` method to `SVG.FX`
+
+### Changed
 - switched from `setInterval` to `requestAnimFrame` for animations
 
 
 ## v0.37 - 2014-01-26
 
+### Added
 - added `get()` to `SVG.Set`
+
+### Changed
 - moved `SVG.PointArray` to a separate file
 
 
 ## v0.36 - 2014-01-25
 
+### Added
 - added `linkTo()`, `addTo()` and `putIn()` methods on `SVG.Element`
+
+### Changed
 - provided more detailed documentation on parent elements
+
+### Fixed
 
 
 ## v0.35 - 2014-01-23
 
+### Added
 - added `SVG.A` element with the `link()`
 
 
 ## v0.34 - 2014-01-23
 
+### Added
 - added `pause()` and `play()` to `SVG.FX`
+
+### Changed
 - storing animation values in `situation` object
 
 
 ## v0.33 - 2014-01-22
 
+### Added
 - added `has()` method to `SVG.Set`
 - added `width()` and `height()` as setter and getter methods on all shapes
-- moved sub-pixel offset fix to be an optional method (e.g. `SVG('drawing').fixSubPixelOffset()`)
 - added `replace()` method to elements
 - added `radius()` method to `SVG.Rect` and `SVG.Ellipse`
 - added reference to parent node in defs
+
+### Changed
+- moved sub-pixel offset fix to be an optional method (e.g. `SVG('drawing').fixSubPixelOffset()`)
 - merged plotable.js and path.js
 
 
 ## v0.32
 
+### Added
 - added library to [cdnjs](http://cdnjs.com)
+


### PR DESCRIPTION
The document [“Keep A CHANGELOG”](http://keepachangelog.com) describes some sensible guidelines for formatting changelog notes.  I think the guidelines make changelogs much more useful and human-friendly.  