### PR TITLE
Adds the intended functionality to call animate functions with multiple parameter

### DIFF
--- a/spec/spec/fx.js
+++ b/spec/spec/fx.js
@@ -2538,7 +2538,7 @@ describe('FX', function() {
 
       spyOn(fx, 'add')
       fx.plot('5 5 30 29 40 19 12 30')
-      expect(fx.add).toHaveBeenCalledWith('plot', '5 5 30 29 40 19 12 30')
+      expect(fx.add).toHaveBeenCalledWith('plot', new SVG.PointArray('5 5 30 29 40 19 12 30'))
     })
 
     it('also accept parameter list', function() {
@@ -2547,7 +2547,7 @@ describe('FX', function() {
 
       spyOn(fx, 'add')
       fx.plot(5, 5, 10, 10)
-      expect(fx.add).toHaveBeenCalledWith('plot', [5, 5, 10, 10])
+      expect(fx.add).toHaveBeenCalledWith('plot', new SVG.PointArray([5, 5, 10, 10]))
     })
   })
 

--- a/src/fx.js
+++ b/src/fx.js
@@ -860,11 +860,11 @@ SVG.extend(SVG.FX, {
   }
   // Add animatable plot
 , plot: function(a, b, c, d) {
-    if(this.target() instanceof SVG.Line && arguments.length == 4) {
+    // Lines can be plotted with 4 arguments
+    if(arguments.length == 4) {
       return this.plot([a, b, c, d])
     }
 
-    // We use arguments here since SVG.Line's plot method can be passed 4 parameters
     return this.add('plot', new (this.target().morphArray)(a))
   }
   // Add leading method

--- a/src/fx.js
+++ b/src/fx.js
@@ -214,7 +214,7 @@ SVG.FX = SVG.invent({
     // updates all animations to the current state of the element
     // this is important when one property could be changed from another property
   , initAnimations: function() {
-      var i, source
+      var i, j, source
       var s = this.situation
 
       if(s.init) return this
@@ -222,12 +222,26 @@ SVG.FX = SVG.invent({
       for(i in s.animations){
         source = this.target()[i]()
 
-        // The condition is because some methods return a normal number instead
-        // of a SVG.Number
-        if(s.animations[i] instanceof SVG.Number)
-          source = new SVG.Number(source)
+        if(!Array.isArray(source)) {
+          source = [source]
+        }
 
-        s.animations[i] = source.morph(s.animations[i])
+        if(!Array.isArray(s.animations[i])) {
+          s.animations[i] = [s.animations[i]]
+        }
+
+        //if(s.animations[i].length > source.length) {
+        //  source.concat = source.concat(s.animations[i].slice(source.length, s.animations[i].length))
+        //}
+
+        for(j = source.length; j--;) {
+          // The condition is because some methods return a normal number instead
+          // of a SVG.Number
+          if(s.animations[i][j] instanceof SVG.Number)
+            source[j] = new SVG.Number(source[j])
+
+          s.animations[i][j] = source[j].morph(s.animations[i][j])
+        }
       }
 
       for(i in s.attrs){
@@ -845,9 +859,13 @@ SVG.extend(SVG.FX, {
     return this
   }
   // Add animatable plot
-, plot: function() {
+, plot: function(a, b, c, d) {
+    if(this.target() instanceof SVG.Line && arguments.length == 4) {
+      return this.plot([a, b, c, d])
+    }
+
     // We use arguments here since SVG.Line's plot method can be passed 4 parameters
-    return this.add('plot', arguments.length > 1 ? [].slice.call(arguments) : arguments[0])
+    return this.add('plot', new (this.target().morphArray)(a))
   }
   // Add leading method
 , leading: function(value) {

--- a/src/textpath.js
+++ b/src/textpath.js
@@ -10,8 +10,9 @@ SVG.TextPath = SVG.invent({
 
   // Add parent method
 , construct: {
+    morphArray: SVG.PathArray
     // Create path for text to run on
-    path: function(d) {
+  , path: function(d) {
       // create textPath element
       var path  = new SVG.TextPath
         , track = this.doc().defs().path(d)


### PR DESCRIPTION
While writing the zoom plugin I discovered, that the fx module didnt cover a usecase which was orginally intended to work. You cant pass multilple parameter to methods when animating them.

"Stop", I hear you saying, "`move()` _does_ expect 2 parameters!". Well yes thats true but the implementation of `move()` breaks it down to `x()` and `y()` which both only take one parameter.

So this wasnt possible: `el.animate().zoom(level, point)`.
This PR aims to fix this while adding the possibility to use `static` values which stay the same while animating. In this case: `point`. When you animate zooming you dont want the point to which you zoom to be animated. It stays the same.

So fx now does the following:
- you set `el.animate().method(val1, val2)`
- if `el.method()` returns the same number of arguments (as array) then all arguments are morphed to each other (the behavior everyone expects)
- however when `el.method()` returns _less_ arguments (e.g. `zoom` only retuns the zoomlvl but no point) it will morph the arguments which are there and let the additional arguments untouched (in case of zoom its `point` which is not changed while zooming)
- if `el.method` returns more arguments the whole fx module will explode

Actually I didnt changed that much code but it has quite an impact :)