### PR TITLE
wraps constructor methods so that they accept objects as shorthand

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -47,19 +47,19 @@ SVG.extend = function (modules, methods) {
   }
 }
 
-var wrapFn = function(method, initializer) {
-  return function(o) {
-    if(!(initializer.prototype instanceof SVG.Element))
-      return method.apply(this, [].slice.call(arguments))
+var wrapFn = function (method, initializer) {
+  // not a constructor we want to change
+  if (!(SVG.Shape && initializer.prototype instanceof SVG.Shape)) {
+    return method
+  }
 
-    if(o instanceof initializer) {
-      return o.clone(this)
-    }
-
-    if(typeof o == 'object') {
+  return function (o) {
+    // if an object is given, we assume thats an attribute list
+    if (typeof o === 'object' && !o.prototype && o.length == null) {
       return this.put(new initializer()).attr(o)
     }
 
+    // in every other case we call the normal constructor
     return method.apply(this, [].slice.call(arguments))
   }
 }
@@ -82,7 +82,7 @@ SVG.invent = function (config) {
     SVG.extend(initializer, config.extend)
   }
 
-  for(var i in config.construct) {
+  for (var i in config.construct) {
     config.construct[i] = wrapFn(config.construct[i], initializer)
   }
 

--- a/src/svg.js
+++ b/src/svg.js
@@ -47,6 +47,23 @@ SVG.extend = function (modules, methods) {
   }
 }
 
+var wrapFn = function(method, initializer) {
+  return function(o) {
+    if(!(initializer.prototype instanceof SVG.Element))
+      return method.apply(this, [].slice.call(arguments))
+
+    if(o instanceof initializer) {
+      return o.clone(this)
+    }
+
+    if(typeof o == 'object') {
+      return this.put(new initializer()).attr(o)
+    }
+
+    return method.apply(this, [].slice.call(arguments))
+  }
+}
+
 // Invent new element
 SVG.invent = function (config) {
   // Create element initializer
@@ -63,6 +80,10 @@ SVG.invent = function (config) {
   // Extend with methods
   if (config.extend) {
     SVG.extend(initializer, config.extend)
+  }
+
+  for(var i in config.construct) {
+    config.construct[i] = wrapFn(config.construct[i], initializer)
   }
 
   // Attach construct method to parent

--- a/src/svg.js
+++ b/src/svg.js
@@ -55,7 +55,7 @@ var wrapFn = function (method, initializer) {
 
   return function (o) {
     // if an object is given, we assume thats an attribute list
-    if (typeof o === 'object' && !o.prototype && o.length == null) {
+    if (o && o.constructor === Object) {
       return this.put(new initializer()).attr(o)
     }
 


### PR DESCRIPTION
- does not work for many edge cases which are uncovered for now

You can pass an object to any constuctor method which applies all attributes directly on the element. In case you passed an instance of a shape it is cloned.
So this works:
```js   
var rect = canvas.rect({
  width:100,
  height:100,
  x:100,
  y:100,
  fill:'#ccc'
})

canvas.group().rect(rect)
canvas.rect(100,100)
```

But this produces errors:
```js
// arrays are also objects
draw.polygon([200, 200])

// passing a value as object produces problems, too
draw.rect(new SVG.Number(100), 100)
```

This branch does not aims to be merged asap. Its merely something we can start with