### PR TITLE
Make width() and height() setters animatable

### DIFF
--- a/spec/spec/fx.js
+++ b/spec/spec/fx.js
@@ -2539,6 +2539,22 @@ describe('FX', function() {
       expect(fx.add).toHaveBeenCalledWith('height', jasmine.objectContaining({value:60}))
     })
   })
+  
+  describe('width()', function() {
+    it('should set width with add()', function() {
+      spyOn(fx, 'add').and.callThrough()
+      fx.width(20)
+      expect(fx.add).toHaveBeenCalledWith('width', jasmine.objectContaining({value:20}))
+    })
+  })
+  
+  describe('height()', function() {
+    it('should set height with add()', function() {
+      spyOn(fx, 'add').and.callThrough()
+      fx.height(20)
+      expect(fx.add).toHaveBeenCalledWith('height', jasmine.objectContaining({value:20}))
+    })
+  })
 
   describe('plot()', function() {
     it('should call add with plot as method', function() {

--- a/src/fx.js
+++ b/src/fx.js
@@ -858,6 +858,14 @@ SVG.extend(SVG.FX, {
 
     return this
   }
+  // Add animatable width
+, width: function(width) {
+    return this.add('width', new SVG.Number(width))
+  }
+  // Add animatable height
+, height: function(height) {
+    return this.add('height', new SVG.Number(height))
+  }
   // Add animatable plot
 , plot: function(a, b, c, d) {
     // Lines can be plotted with 4 arguments


### PR DESCRIPTION
Adding animation capabilities for width() and height() setters. (Indicated as currently animatable in documentation). Unit tests included.
Refers to #675 

To be reviewed as I'm not 100% sure about my code !
