### PR TITLE
Add missing type definitions to svg.js.d.ts

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -62,6 +62,7 @@ declare namespace svgjs {
 
     // attr.js
     interface Element {
+        attr(): object;
         attr(name: string): any;
         attr(obj: Object): this;
         attr(name: string, value: any, namespace?: string): this;
@@ -712,6 +713,7 @@ declare namespace svgjs {
     // rect.js
     export interface Rect extends Shape {
         new (): Rect;
+        radius(x: number, y?: number): this;
     }
     interface Library { Rect: Rect; }
     interface Container {
@@ -821,9 +823,9 @@ declare namespace svgjs {
     }
     interface FontData {
         family?: string;
-        size?: number;
+        size?: NumberAlias;
         anchor?: string;
-        leading?: string;
+        leading?: NumberAlias;
         weight?: string;
         style?: string
     }
@@ -842,8 +844,9 @@ declare namespace svgjs {
         text(text: string): this;
         text(block: (text: Text) => void): this;
         size(fontSize: NumberAlias): this;
-        leading(leading: number): this;
-        lines(): number;
+        leading(): number;
+        leading(leading: NumberAlias): this;
+        lines(): Set;
         rebuild(enabled: boolean): this;
         build(enabled: boolean): this;
         plain(text: string): this;
@@ -986,6 +989,7 @@ declare namespace svgjs {
         attr(name: string, value: any, namespace?: string): Animation;
         attr(obj: Object): Animation;
         attr(name: string): any;
+        attr(): object;
 
         viewbox(x: number, y: number, w: number, h: number): Animation;
 


### PR DESCRIPTION
Updated:

* `.attr()` getter method is missing in `Element` and `Animation` 
* `.leading()` getter method is missing in `Text`
* `.lines()` getter method in `Text` is actually return a `Set` of `Tspan`
* `.radius(x: number, y?: number)` method is missing in `Rect`
* `FontData` can accept `size` and `leading` property as `NumberAlias`