### PR TITLE
TypeScript fixes and remove unused parameter

### DIFF
--- a/src/doc.js
+++ b/src/doc.js
@@ -57,7 +57,7 @@ SVG.Doc = SVG.invent({
     }
     // Fix for possible sub-pixel offset. See:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=608812
-  , spof: function(spof) {
+  , spof: function() {
       var pos = this.node.getScreenCTM()
 
       if (pos)

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -216,7 +216,7 @@ declare namespace svgjs {
         namespace(): this;
         defs(): Defs;
         parent(): HTMLElement;
-        spof(spof): this;
+        spof(): this;
         remove(): this;
     }
     interface Library { Doc: Doc; }
@@ -364,7 +364,7 @@ declare namespace svgjs {
         at(opts: StopProperties): Stop;
         update(block?: Function): this;
         fill(): string;
-        fill(...any): never;
+        fill(...params: any[]): never;
         toString(): string;
         from(x: number, y: number): this;
         to(x: number, y: number): this;
@@ -393,7 +393,7 @@ declare namespace svgjs {
         to(): string;
         show(target: string): this;
         show(): string;
-        show(...any): never;
+        show(...params: any[]): never;
         target(target: string): this;
         target(): string;
     }
@@ -638,7 +638,7 @@ declare namespace svgjs {
     export interface Pattern extends Container {
         new (): Pattern;
         fill(): string;
-        fill(...any): never;
+        fill(...rest: any[]): never;
         update(block: (pattern: Pattern) => void): this;
         toString(): string;
     }
@@ -916,7 +916,7 @@ declare namespace svgjs {
         f?: number;
     }
     export interface Transformation {
-        new (...Transform): Transformation;
+        new (...transform: Transform[]): Transformation;
         new (source: Transform, inversed?: boolean): Transformation;
         at(pos: number): Matrix;
         undo(transform: Transform): this


### PR DESCRIPTION
Hi, thanks for this awesome lib :) 

The default TypeScript declaration file gave me a few syntax errors when I tried to use it. These are the fixes that made it work for me. I have never used TS before, so this is more or less the result of "hacking by error message", but the changes are fairly simple syntax fixes.

For some of the stuff I touched, at least in the Transformation interface, I'm not sure the declaration exactly matches all use cases of the JS function even now. But I don't know enough about TS or svg.js to be certain.

Going through function definitions, I also found the function spof() in doc.js which had an unused parameter spof (whose type was undeclared in the declaration, hence a syntax error). I removed the parameter.