### PR TITLE
Use full URL in marker URL

### DIFF
--- a/src/marker.js
+++ b/src/marker.js
@@ -32,7 +32,7 @@ SVG.Marker = SVG.invent({
     }
     // Return the fill id
   , toString: function() {
-      return 'url(#' + this.id() + ')'
+      return 'url("' + document.URL + '#' + this.id() + '")'
     }
   }
 


### PR DESCRIPTION
This will fix issue in some browsers (ex: Safari) the marker is not showing when having `<base href="/">` 