### PR TITLE
Add getter form of svg method to TypeScript definition

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -278,6 +278,7 @@ declare namespace svgjs {
         native(): LinkedHTMLElement;
 
         svg(svg: string): this;
+        svg(): string;
         
         writeDataToDom(): this,
         setData(data: object): this,


### PR DESCRIPTION
This adds the getter form of the `svg` method to the TypeScript definitions.