### PR TITLE
Fix typings for arrays that takes plot method.

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -423,8 +423,7 @@ declare namespace svgjs {
 
     // line.js
     interface ArrayPoint extends Array<number> { }
-    type ArrayAsPoint = [number, number];
-    type PointArrayAlias = ArrayPoint | number[] | ArrayAsPoint[] | PointArray | string;
+    type PointArrayAlias = ArrayPoint[] | number[] | PointArray | string;
     
     export interface Line extends Shape {
         new (): Line;

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -423,7 +423,8 @@ declare namespace svgjs {
 
     // line.js
     interface ArrayPoint extends Array<number> { }
-    type PointArrayAlias = ArrayPoint | number[] | PointArray | string;
+    type ArrayAsPoint = [number, number];
+    type PointArrayAlias = ArrayPoint | number[] | ArrayAsPoint[] | PointArray | string;
     
     export interface Line extends Shape {
         new (): Line;


### PR DESCRIPTION
I can't use array like `[[0, 235], [245, 123], [521, 34]]` as array of points. This fix makes it possible to use `ArrayPoint[]` in with plot method in TS.

Thank you.