### PR TITLE
Revive Svg.Set

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ var headerShort = '/*! <%= pkg.name %> v<%= pkg.version %> <%= pkg.license %>*/;
 // all files in the right order (currently we don't use any dependency management system)
 var parts = [
   'src/svg.js',
+  'src/set.js',
   'src/regex.js',
   'src/utilities.js',
   'src/default.js',

--- a/src/set.js
+++ b/src/set.js
@@ -4,89 +4,150 @@ SVG.Set = SVG.invent({
     for (var i = members.length - 1; i >= 0; --i) {
       this[i] = members[i]
     }
-  }
+  },
   // Add class methods
-, extend: {
+  extend: {
     // Add element to set
-    add: function() {
+    add: function () {
       Array.prototype.push.apply(this, arguments)
       return this
-    }
+    },
     // Remove element from set
-  , remove: function(element) {
+    remove: function (element) {
       var i = this.index(element)
 
       // remove given child
-      if (i > -1)
+      if (i > -1) {
         Array.prototype.splice.call(this, i, 1)
+      }
 
       return this
-    }
-  , each: function (block, value) {
-      if (typeof block == 'function') {
-        for (var i = 0, il = this.members.length; i < il; i++) {
-          block.call(this[i], i, this)
-        }
-      } else {
-        for (var i = 0, il = this.members.length; i < il; i++) {
-          this[i][block].call(this[i], value)
-        }
+    },
+    each: function (block) {
+      for (var i = 0, il = this.members.length; i < il; i++) {
+        block.call(this[i], i, this)
       }
-    }
+    },
     // Restore to defaults
-  , clear: function() {
-      while(this.length--) {
-        delete this[this.length-1]
+    clear: function () {
+      while (this.length) {
+        delete this[--this.length]
       }
       return this
-    }
+    },
     // Checks if a given element is present in set
-  , has: function(element) {
+    has: function (element) {
       return this.index(element) >= 0
-    }
+    },
     // retuns index of given element in set
-  , index: function(element) {
+    index: function (element) {
       return Array.prototype.indexOf(this, element)
-    }
+    },
     // Get member at given index
-  , get: function(i) {
+    get: function (i) {
       return this[i]
-    }
+    },
     // Get first member
-  , first: function() {
-      return this.get(0)
-    }
+    first: function () {
+      return this[0]
+    },
     // Get last member
-  , last: function() {
-      return this.get(this.length - 1)
-    }
+    last: function () {
+      return this[this.length - 1]
+    },
     // Default value
-  , valueOf: function() {
-      return Array.prototype.slice.call(this)
-    }
+    valueOf: function () {
+      return this.slice()
+    },
     // Get the bounding box of all members included or empty box if set has no items
-  , bbox: function(){
+    bbox: function () {
       // return an empty box of there are no members
-      if (this.length == 0)
+      if (this.length === 0) {
         return new SVG.Box()
+      }
 
       // get the first rbox and update the target bbox
       var rbox = this[0].rbox(this[0].doc())
 
-      this.each(function() {
+      this.each(function () {
         // user rbox for correct position and visual representation
         rbox = rbox.merge(this.rbox(this.doc()))
       })
 
       return rbox
     }
-  }
+  },
 
   // Add parent method
-, construct: {
+  construct: {
     // Create a new set
-    set: function(members) {
+    set: function (members) {
       return new SVG.Set(members)
     }
   }
 })
+
+;['splice', 'push', 'pop', 'shift', 'unshift', 'forEach', 'reduce', 'indexOf', 'sort'].forEach(function (method) {
+  SVG.Set.prototype[method] = Array.prototype[method]
+})
+
+;['map', 'filter', 'slice', 'concat'].forEach(function (method) {
+  SVG.Set.prototype[method] = function () {
+    return new SVG.Set(Array.prototype[method].apply(this.valueOf(), arguments))
+  }
+})
+
+SVG.FX.Set = SVG.invent({
+  // Initialize node
+  create: function (set) {
+    // store reference to set
+    this.set = set
+  }
+})
+
+// Alias methods
+SVG.Set.inherit = function () {
+  var methods = []
+  var m
+
+  // gather shape methods
+  for (m in SVG.Shape.prototype) {
+    if (typeof SVG.Shape.prototype[m] === 'function' && typeof SVG.Set.prototype[m] !== 'function') {
+      methods.push(m)
+    }
+  }
+
+  // apply shape aliasses
+  methods.forEach(function (method) {
+    SVG.Set.prototype[method] = function () {
+      for (var i = 0, il = this.length; i < il; ++i) {
+        if (this[i] && typeof this[i][method] === 'function') {
+          this[i][method].apply(this[i], arguments)
+        }
+      }
+
+      return method === 'animate' ? (this.fx || (this.fx = new SVG.FX.Set(this))) : this
+    }
+  })
+
+  // clear methods for the next round
+  methods = []
+
+  // gather fx methods
+  for (m in SVG.FX.prototype) {
+    if (typeof SVG.FX.prototype[m] === 'function' && typeof SVG.FX.Set.prototype[m] !== 'function') {
+      methods.push(m)
+    }
+  }
+
+  // apply fx aliasses
+  methods.forEach(function (method) {
+    SVG.FX.Set.prototype[method] = function () {
+      for (var i = 0, il = this.set.length; i < il; i++) {
+        this.set[i].fx[method].apply(this.set[i].fx, arguments)
+      }
+
+      return this
+    }
+  })
+}

--- a/src/set.js
+++ b/src/set.js
@@ -1,0 +1,92 @@
+SVG.Set = SVG.invent({
+  create: function (members) {
+    this.length = members.length
+    for (var i = members.length - 1; i >= 0; --i) {
+      this[i] = members[i]
+    }
+  }
+  // Add class methods
+, extend: {
+    // Add element to set
+    add: function() {
+      Array.prototype.push.apply(this, arguments)
+      return this
+    }
+    // Remove element from set
+  , remove: function(element) {
+      var i = this.index(element)
+
+      // remove given child
+      if (i > -1)
+        Array.prototype.splice.call(this, i, 1)
+
+      return this
+    }
+  , each: function (block, value) {
+      if (typeof block == 'function') {
+        for (var i = 0, il = this.members.length; i < il; i++) {
+          block.call(this[i], i, this)
+        }
+      } else {
+        for (var i = 0, il = this.members.length; i < il; i++) {
+          this[i][block].call(this[i], value)
+        }
+      }
+    }
+    // Restore to defaults
+  , clear: function() {
+      while(this.length--) {
+        delete this[this.length-1]
+      }
+      return this
+    }
+    // Checks if a given element is present in set
+  , has: function(element) {
+      return this.index(element) >= 0
+    }
+    // retuns index of given element in set
+  , index: function(element) {
+      return Array.prototype.indexOf(this, element)
+    }
+    // Get member at given index
+  , get: function(i) {
+      return this[i]
+    }
+    // Get first member
+  , first: function() {
+      return this.get(0)
+    }
+    // Get last member
+  , last: function() {
+      return this.get(this.length - 1)
+    }
+    // Default value
+  , valueOf: function() {
+      return Array.prototype.slice.call(this)
+    }
+    // Get the bounding box of all members included or empty box if set has no items
+  , bbox: function(){
+      // return an empty box of there are no members
+      if (this.length == 0)
+        return new SVG.Box()
+
+      // get the first rbox and update the target bbox
+      var rbox = this[0].rbox(this[0].doc())
+
+      this.each(function() {
+        // user rbox for correct position and visual representation
+        rbox = rbox.merge(this.rbox(this.doc()))
+      })
+
+      return rbox
+    }
+  }
+
+  // Add parent method
+, construct: {
+    // Create a new set
+    set: function(members) {
+      return new SVG.Set(members)
+    }
+  }
+})


### PR DESCRIPTION
This PR brings back SVG.Set which was removed earlier.
It is now implemented as what is called an array-like object. This is nothing more than an object with numeral properties and a length property.
This has the benefit that we can use all array methods on it and it will just work.
It is designed after the proposal #645. The map/collect method is missing atm but can be easily added later.