### PR TITLE
Fix typings for memory.js remember method order

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -554,8 +554,8 @@ declare namespace svgjs {
     // memory.js
     interface Element {
         remember(name: string, value: any): this;
-        remember(obj: Object): this;
         remember(name: string): any;
+        remember(obj: Object): this;
         forget(...keys: string[]): this;
         forget(): this;
         memory(): Object;


### PR DESCRIPTION
I am using this library in TypeScript.
In my case, first parameter was recognized as an Object.

# AsIs
```
import * as SVG from 'svg.js';
...
const items = this.polyline.remember('polygonCircle') as any as SVG.Element[];
```

Definition order changed
# ToBe
```
import * as SVG from 'svg.js';
...
const items = this.polyline.remember('polygonCircle') as SVG.Element[];
```

In TypeScript, method order is very important.
https://www.typescriptlang.org/docs/handbook/declaration-merging.html

Thanks