### PR TITLE
make ungroup working on groups and nested for one depths

### DIFF
--- a/src/flatten.js
+++ b/src/flatten.js
@@ -1,6 +1,9 @@
 SVG.extend(SVG.Parent, {
   flatten: function (parent) {
-    if (this instanceof SVG.Defs) return this
+    // flattens is only possible for nested svgs and groups
+    if (!(this instanceof SVG.G || this instanceof SVG.Doc)) {
+      return this
+    }
 
     parent = parent || (this instanceof SVG.Doc && this.isRoot() ? this : this.parent(SVG.Parent))
 
@@ -12,6 +15,23 @@ SVG.extend(SVG.Parent, {
 
     // we need this so that SVG.Doc does not get removed
     this.node.firstElementChild || this.remove()
+
+    return this
+  },
+  ungroup: function (parent) {
+    // ungroup is only possible for nested svgs and groups
+    if (!(this instanceof SVG.G || (this instanceof SVG.Doc && !this.isRoot()))) {
+      return this
+    }
+
+    parent = parent || this.parent(SVG.Parent)
+
+    this.each(function () {
+      return this.toParent(parent)
+    })
+
+    // we need this so that SVG.Doc does not get removed
+    this.remove()
 
     return this
   }


### PR DESCRIPTION
In #826 I talked about having flatten and ungroup as methods. This PR i sthe implementation. 

Ungroup breaks up groups and nested svgs like when you would ungroup elements in photoshop.
Flatten just makes the whole svg structure flat.