### PR TITLE
WIP: type definitions fixed for selector.js + added click method for …

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -754,10 +754,10 @@ declare namespace svgjs {
     // selector.js
     interface Library {
         get(id: string): Element;
-        select(query: string, parent: HTMLElement): Set;
+        select(query: string): Set;
     }
     interface Parent {
-        select(query: string): Set;
+        select(query: string, parent: HTMLElement): Set;
     }
 
     // set.js
@@ -775,6 +775,7 @@ declare namespace svgjs {
         last(): Element;
         valueOf(): Element[];
         bbox(): BBox;
+        click(cb: Function): Set;
     }
     interface Container { set(members?: Element[]): Set; }
     interface Library { Set: Set; }

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -754,10 +754,10 @@ declare namespace svgjs {
     // selector.js
     interface Library {
         get(id: string): Element;
-        select(query: string): Set;
+        select(query: string, parent?: HTMLElement): Set;
     }
     interface Parent {
-        select(query: string, parent: HTMLElement): Set;
+        select(query: string): Set;
     }
 
     // set.js


### PR DESCRIPTION
…set.js

While testing today the svg.js library with typescript, I have found two possible bugs / missing things, which described in [this post](https://stackoverflow.com/questions/49387057/using-svg-select-method-with-class-selector-of-the-svg-js-library-doesnt-work). First, the `select()` method didn't work like mentioned in [documentation](http://svgjs.com/referencing/#svg-select):

![](https://i.stack.imgur.com/ehPH1.jpg)

Second, for the result of selection, there was no `click()` method:

![](https://i.stack.imgur.com/owYpq.jpg)

I have pushed a possible solution and my first ever pull request to open source project on GitHub, so I hope to do not mess up with anything. Also since I haven't found any contributing instructions in this repository, I've tried to follow [the suggested guide](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github). Let me know if I missed something like test etc (I did run `npm run test`), this would be useful knowledge for me for the future contributions.