### PR TITLE
reference() method should return null if reference doesn't exsit

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -159,9 +159,15 @@ SVG.Element = SVG.invent({
   , toggleClass: function(name) {
       return this.hasClass(name) ? this.removeClass(name) : this.addClass(name)
     }
-    // Get referenced element form attribute value
+    // Get referenced element from attribute value
   , reference: function(attr) {
-      return SVG.get(this.attr(attr))
+      try{
+        return SVG.get(this.attr(attr))
+      }
+      catch(e){
+        return null // TODO: Need to decide if return null or undefined 
+      }
+      
     }
     // Returns the parent element instance
   , parent: function(type) {


### PR DESCRIPTION
Problem: reference() throws TypeError  if reference doesn't exist. More details: https://github.com/svgdotjs/svg.js/issues/840 

This PR fixes the issue by adding a try/catch block in the reference() method. If reference doesn't exist, it should return `null `or `undefined `.

TODO: I am leaving it up to the maintainers of SVGjs to decide if it should return null or undefined 