### PR TITLE
Add global reference to support 'window' in bundlers - fixes #767

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -1,5 +1,9 @@
+// Find global reference - uses 'this' by default when available,
+// falls back to 'window' otherwise (for bundlers like Webpack)
+var globalRef = (typeof this !== "undefined") ? this : window;
+
 // The main wrapping element
-var SVG = this.SVG = function(element) {
+var SVG = globalRef.SVG = function (element) {
   if (SVG.supported) {
     element = new SVG.Doc(element)
     

--- a/src/svg.js
+++ b/src/svg.js
@@ -3,7 +3,7 @@
 var globalRef = (typeof this !== "undefined") ? this : window;
 
 // The main wrapping element
-var SVG = globalRef.SVG = function (element) {
+var SVG = globalRef.SVG = function(element) {
   if (SVG.supported) {
     element = new SVG.Doc(element)
     


### PR DESCRIPTION
This PR addresses the discussion in issue #767 - Bundling issues when using webpack and the `this` reference that was hardcoded.