### PR TITLE
Add node document-fragment type check

### DIFF
--- a/src/doc.js
+++ b/src/doc.js
@@ -53,7 +53,7 @@ SVG.Doc = SVG.invent({
     }
     // custom parent method
   , parent: function() {
-      if(!this.node.parentNode || this.node.parentNode.nodeName == '#document') return null
+      if(!this.node.parentNode || this.node.parentNode.nodeName == '#document' || this.node.parentNode.nodeName == '#document-fragment') return null
       return this.node.parentNode
     }
     // Fix for possible sub-pixel offset. See:

--- a/src/element.js
+++ b/src/element.js
@@ -178,7 +178,7 @@ SVG.Element = SVG.invent({
       // loop trough ancestors if type is given
       while(parent && parent.node instanceof window.SVGElement){
         if(typeof type === 'string' ? parent.matches(type) : parent instanceof type) return parent
-        if(!parent.node.parentNode || parent.node.parentNode.nodeName == '#document') return null // #759, #720
+        if(!parent.node.parentNode || parent.node.parentNode.nodeName == '#document' || parent.node.parentNode.nodeName == '#document-fragment') return null // #759, #720
         parent = SVG.adopt(parent.node.parentNode)
       }
     }


### PR DESCRIPTION
It solves the `node.getAttribute is not a function` issue in Shadow DOM.