### PR TITLE
Add PointArray.transform by analogy to Point.transform

### DIFF
--- a/spec/spec/pointarray.js
+++ b/spec/spec/pointarray.js
@@ -1,0 +1,28 @@
+describe('PointArray', function() {
+  const squareString = '0,0 1,0 1,1 0,1';
+  const square = new SVG.PointArray(squareString)
+
+  describe('toString()', function() {
+    it('round trips with string', () => {
+      expect(square.toString()).toEqual(squareString)
+    })
+  })
+
+  describe('transform()', function() {
+    it('translates correctly', () => {
+      const translation = new SVG.Matrix().translate(2,1)
+      const newSquare = square.transform(translation)
+      expect(newSquare.toString()).toEqual('2,1 3,1 3,2 2,2')
+    })
+
+    it('transforms like Point', () => {
+      const matrix = new SVG.Matrix(1, 2, 3, 4, 5, 6)
+      const newSquare = square.transform(matrix)
+      for (let i = 0; i < square.length; i++) {
+        const squarePoint = new SVG.Point(square[i])
+        const newSquarePoint = new SVG.Point(newSquare[i])
+        expect(squarePoint.transform(matrix)).toEqual(newSquarePoint)
+      }
+    })
+  })
+})

--- a/src/types/PointArray.js
+++ b/src/types/PointArray.js
@@ -73,12 +73,14 @@ extend(PointArray, {
 
   // transform points with matrix (similar to Point.transform)
   transform (m) {
-    let points = []
+    const points = []
 
     for (let point of this) {
       // Perform the matrix multiplication
-      points.push([m.a * point.x + m.c * point.y + m.e,
-        m.b * point.x + m.d * point.y + m.f])
+      points.push([
+        m.a * point[0] + m.c * point[1] + m.e,
+        m.b * point[0] + m.d * point[1] + m.f
+      ])
     }
 
     // Return the required point

--- a/src/types/PointArray.js
+++ b/src/types/PointArray.js
@@ -78,12 +78,12 @@ extend(PointArray, {
     for (let point of this) {
       // Perform the matrix multiplication
       points.push([m.a * point.x + m.c * point.y + m.e,
-                   m.b * point.x + m.d * point.y + m.f])
+        m.b * point.x + m.d * point.y + m.f])
     }
 
     // Return the required point
     return new PointArray(points)
-  }
+  },
 
   // Move point string
   move (x, y) {

--- a/src/types/PointArray.js
+++ b/src/types/PointArray.js
@@ -75,7 +75,8 @@ extend(PointArray, {
   transform (m) {
     const points = []
 
-    for (let point of this) {
+    for (let i = 0; i < this.length; i++) {
+      const point = this[i]
       // Perform the matrix multiplication
       points.push([
         m.a * point[0] + m.c * point[1] + m.e,

--- a/src/types/PointArray.js
+++ b/src/types/PointArray.js
@@ -71,6 +71,20 @@ extend(PointArray, {
     return points
   },
 
+  // transform points with matrix (similar to Point.transform)
+  transform (m) {
+    let points = []
+
+    for (let point of this) {
+      // Perform the matrix multiplication
+      points.push([m.a * point.x + m.c * point.y + m.e,
+                   m.b * point.x + m.d * point.y + m.f])
+    }
+
+    // Return the required point
+    return new PointArray(points)
+  }
+
   // Move point string
   move (x, y) {
     var box = this.bbox()


### PR DESCRIPTION
I recently had occasion to want to transform the points in an `SVG.Polygon` according to a transformation matrix.  (The motivation is to "inline" `transform` attributes into the point coordinates themselves, for software that supports SVG but not the `transform` attribute.)  `SVG.Polygon.array` reveals the `SVG.PointArray` that represents the coordinates, and `SVG.Polygon.plot` lets me put a transformed `PointArray` back into the polygon.  What's missing is an `SVG.PointArray.transform` (essentially a loop over `SVG.Point.transform`) to transform the `PointArray` according to a given matrix.

This PR adds this functionality.  If you like the proposed addition in principle, I can write tests and documentation.