### PR TITLE
Added missing key/value overload for 'text.font()'

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -840,9 +840,11 @@ declare namespace svgjs {
     }
     interface Parent {
         font(font: FontData): this;
+        font(key: string, value: any): this;
     }
     interface Text {
         font(font: FontData): this;
+        font(key: string, value: any): this;
     }
 
     // text.js


### PR DESCRIPTION
Applied against 2.x branch