### PR TITLE
Fixed path transformation when box width or height is 0

### DIFF
--- a/spec/spec/path.js
+++ b/spec/spec/path.js
@@ -164,6 +164,15 @@ describe('Path', function() {
       expect(path.height()).toBe(525)
       expect(path.width() / path.height()).toBeCloseTo(box.width / box.height)
     })
+    it('doesn\'t scale width/height when their value is 0', function() {
+      path = draw.path('M0 0L0 100')
+      path.size(500, 500)
+      expect(path.attr('d')).toBe('M0 0L0 500 ')
+
+      path = draw.path('M0 0L100 0')
+      path.size(500, 500)
+      expect(path.attr('d')).toBe('M0 0L500 0 ')
+    })
   })
 
   describe('scale()', function() {

--- a/src/types/PathArray.js
+++ b/src/types/PathArray.js
@@ -182,6 +182,11 @@ extend(PathArray, {
     var box = this.bbox()
     var i, l
 
+    // If the box width or height is 0 then we ignore
+    // transformations on the respective axis
+    box.width = box.width === 0 ? 1 : box.width
+    box.height = box.height === 0 ? 1 : box.height
+    
     // recalculate position of all points according to new size
     for (i = this.length - 1; i >= 0; i--) {
       l = this[i][0]

--- a/src/types/PathArray.js
+++ b/src/types/PathArray.js
@@ -186,7 +186,7 @@ extend(PathArray, {
     // transformations on the respective axis
     box.width = box.width === 0 ? 1 : box.width
     box.height = box.height === 0 ? 1 : box.height
-    
+
     // recalculate position of all points according to new size
     for (i = this.length - 1; i >= 0; i--) {
       l = this[i][0]


### PR DESCRIPTION
@Fuzzyma Since there are paths that have 0 width/height (i.e. straight line) the original code was generating invalid path data. This fixes this issue.