### PR TITLE
chore(package): specify npm packed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
   "github": "https://github.com/svgdotjs/svg.js",
   "license": "MIT",
   "typings": "./svg.js.d.ts",
+  "files": [
+    "/dist",
+    "README.md",
+    "LICENSE.txt",
+    "CHANGELOG.md",
+    "svg.js.d.ts"
+  ],
   "scripts": {
     "build": "npm run fix && npm run rollup",
     "build:polyfills": "npx rollup -c .config/rollup.polyfills.js",


### PR DESCRIPTION
Actually the whole package is published to the npm registry. The `files` property specifies the files that should be bundled.