### PR TITLE
Add mouseenter()/mouseleave() function definition to types.

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -1241,6 +1241,8 @@ declare module "@svgdotjs/svg.js" {
         mouseout(cb: Function | null): this;
         mouseover(cb: Function | null): this;
         mouseup(cb: Function | null): this;
+        mouseenter(cb: Function | null): this;
+        mouseleave(cb: Function | null): this;
         move(x: NumberAlias, y: NumberAlias): this;
         native(): LinkedHTMLElement;
         next(): Element;


### PR DESCRIPTION
I found missing function definitions.
https://github.com/svgdotjs/svg.js/blob/master/src/modules/optional/sugar.js#L167-L168
