### PR TITLE
…

### DIFF
--- a/src/animation/Timeline.js
+++ b/src/animation/Timeline.js
@@ -44,17 +44,10 @@ export default class Timeline extends EventTarget {
     this._stepImmediate = this._stepFn.bind(this, true)
   }
 
-  // returns information on each runner in the timeline.
-  // (start, duration, end, and runner)
-
-  getSchedule () {
-    return this._runners.map(makeSchedule)
-  }
-
   // schedules a runner on the timeline
   schedule (runner, delay, when) {
     if (runner == null) {
-      return this.getSchedule()
+      return this._runners.map(makeSchedule)
     }
 
     // The start time for the next animation can either be given explicitly,

--- a/src/animation/Timeline.js
+++ b/src/animation/Timeline.js
@@ -44,10 +44,17 @@ export default class Timeline extends EventTarget {
     this._stepImmediate = this._stepFn.bind(this, true)
   }
 
+  // returns information on each runner in the timeline.
+  // (start, duration, end, and runner)
+
+  getSchedule () {
+    return this._runners.map(makeSchedule)
+  }
+
   // schedules a runner on the timeline
   schedule (runner, delay, when) {
     if (runner == null) {
-      return this._runners.map(makeSchedule)
+      return this.getSchedule()
     }
 
     // The start time for the next animation can either be given explicitly,

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -783,8 +783,8 @@ declare module "@svgdotjs/svg.js" {
         constructor()
         constructor(fn: Function)
 
-        getSchedule(): ScheduledRunnerInfo[]
-        schedule(runner?: Runner, delay?: number, when?: string): ( this | ScheduledRunnerInfo[] )
+        schedule(runner: Runner, delay?: number, when?: string): this
+        schedule(): ScheduledRunnerInfo[]
         unschedule(runner: Runner): this
         getEndTime(): number
         updateTime(): this

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -772,11 +772,19 @@ declare module "@svgdotjs/svg.js" {
     }
 
     // Timeline.js
+    interface ScheduledRunnerInfo {
+        start: number
+        duration: number
+        end: number
+        runner: Runner
+    }
+
     class Timeline extends EventTarget {
         constructor()
         constructor(fn: Function)
 
-        schedule(runner?: Runner, delay?: number, when?: string): this
+        getSchedule(): ScheduledRunnerInfo[]
+        schedule(runner?: Runner, delay?: number, when?: string): ( this | ScheduledRunnerInfo[] )
         unschedule(runner: Runner): this
         getEndTime(): number
         updateTime(): this


### PR DESCRIPTION
It was difficult to use the zero-parameter form of `Timeline.schedule()` with TypeScript. The `svg.js.d.ts` file didn't include the return type for a list of runner infos, and adding it still made it harder than it should be to iterate over it type safely. 

In this commit I:

1. Added the type information for `ScheduledRunnerInfo`, and updated the Timeline types to include it as a return type for `schedule`

2. Added a new function to Timeline, `getSchedule`, that simply returns the runner list. This seems to be cleaner than having the original `schedule` that can return two wildly different things.

I didn't remove the old functionality, so `schedule()` is still compatible. I suggest we might want to deprecate that old form at some point.