### PR TITLE
Add optional string type to Runner.ease

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -851,7 +851,7 @@ declare module "@svgdotjs/svg.js" {
         reset(): this
         finish(): this
         reverse(r?: boolean): this
-        ease(fn: Function): this
+        ease(fn: Function | string): this
         active(): boolean
         active(a: boolean): this
         addTransform(m: Matrix): this


### PR DESCRIPTION
The ease method on the runner takes the same constructor strings as the Ease class, so you can do things like element.animate(1000).ease('-').rotate(360).loop() 
Currently typescript throws an error saying that ease only accepts a Function as an argument.