### PR TITLE
Fix types for List and ForeignObject (same line separators)

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -555,11 +555,10 @@ declare module "@svgdotjs/svg.js" {
         to(a: any): Morphable;
     }
 
-    type ListEachCallback<T extends ElementAlias> =
-        (el: T, index: number, list: List<T>) => any;
+    type ListEachCallback<T> = (el: T, index: number, list: List<T>) => any;
 
     // List.js
-    class List<T extends ElementAlias> extends BuiltInArray<T> {
+    class List<T> extends BuiltInArray<T> {
         each(fn: ListEachCallback<T>): List<any>;
         each(name: string, ...args: any[]): List<any>;
         toArray(): T[];

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -555,13 +555,14 @@ declare module "@svgdotjs/svg.js" {
         to(a: any): Morphable;
     }
 
-    type ListEachCallback<T> = (el: T, index: number, list: List<T>) => any
+    type ListEachCallback<T extends ElementAlias> =
+        (el: T, index: number, list: List<T>) => any;
 
     // List.js
-    class List<T> extends BuiltInArray<T> {
-        each(fn: ListEachCallback<T>): List<any>
-        each(name: string, ...args: any[]): List<any>
-        toArray(): T[]
+    class List<T extends ElementAlias> extends BuiltInArray<T> {
+        each(fn: ListEachCallback<T>): List<any>;
+        each(name: string, ...args: any[]): List<any>;
+        toArray(): T[];
     }
 
     class Eventobject {
@@ -1405,9 +1406,9 @@ declare module "@svgdotjs/svg.js" {
 
     // ForeignObject.js
     class ForeignObject extends Element {
-        constructor(node?: SVGForeignObjectElement, attrs?: object)
-        constructor(attrs?: object)
-        add(element: Dom, i?: number): ForeignObject
+        constructor(node?: SVGForeignObjectElement, attrs?: object);
+        constructor(attrs?: object);
+        add(element: Dom, i?: number): this;
     }
 
     // image.js


### PR DESCRIPTION
Fixes typescript errors List and ForeignObject introduced in #1123 and hopefully with same line separators.