### PR TITLE
Clone without assigning new IDs

### DIFF
--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -96,7 +96,8 @@ const config = (node, min, esm = false) => ({
       : node ? './dist/svg.node.js'
       : min ? './dist/svg.min.js'
       : './dist/svg.js',
-    format: esm ? 'esm' : node ? 'cjs' : 'iife',
+    // See https://stackoverflow.com/questions/54489234/trouble-loading-svgdotjs-svg-js-3-0-11-in-typescript-test-code-managed-by-j
+    format: esm ? 'esm' : node ? 'cjs' : 'umd',
     name: 'SVG',
     sourcemap: true,
     banner: headerLong,

--- a/spec/spec/elements/Dom.js
+++ b/spec/spec/elements/Dom.js
@@ -165,12 +165,20 @@ describe('Dom.js', function () {
       expect(clone.children()).toEqual([])
     })
 
-    it('assigns a new id to the element and to child elements', () => {
+    it('assigns a new id to the element and to child elements by default', () => {
       const group = new G().id('group')
       const rect = group.rect(100, 100).id('rect')
       const clone = group.clone()
       expect(clone.get(0).id()).not.toBe(rect.id())
       expect(clone.id()).not.toBe(group.id())
+    })
+
+    it('does not assign a new id to the element and to child elements', () => {
+      const group = new G().id('group')
+      const rect = group.rect(100, 100).id('rect')
+      const clone = group.clone(true, false)
+      expect(clone.get(0).id()).toBe(rect.id())
+      expect(clone.id()).toBe(group.id())
     })
 
     it('returns an instance of the same class the method was called on', () => {

--- a/src/elements/Dom.js
+++ b/src/elements/Dom.js
@@ -67,12 +67,17 @@ export default class Dom extends EventTarget {
   }
 
   // Clone element
-  clone (deep = true) {
+  clone (deep = true, assignNewIds = true) {
     // write dom data to the dom so the clone can pickup the data
     this.writeDataToDom()
 
-    // clone element and assign new id
-    return new this.constructor(assignNewId(this.node.cloneNode(deep)))
+    // clone element
+    var nodeClone = this.node.cloneNode(deep);
+    if (assignNewIds) {
+      // assign new id
+      nodeClone = assignNewId(nodeClone);
+    }
+    return new this.constructor(nodeClone)
   }
 
   // Iterates over all children and invokes a given block

--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -933,7 +933,7 @@ declare module "@svgdotjs/svg.js" {
         addTo(parent: Dom | HTMLElement | string): this
         children(): List<Element>;
         clear(): this;
-        clone(): this;
+        clone(deep?: boolean, assignNewIds?: boolean): this;
         each(block: (index: number, children: Element[]) => void, deep?: boolean): this;
         element(element: string, inherit?: object): this;
         first(): Element;
@@ -1180,7 +1180,7 @@ declare module "@svgdotjs/svg.js" {
         click(cb: Function | null): this;
         clipper(): ClipPath;
         clipWith(element: Element): this;
-        clone(): this;
+        clone(deep?: boolean, assignNewIds?: boolean): this;
         ctm(): Matrix;
         cx(): number;
         cx(x: number): this;


### PR DESCRIPTION
This PR is related to https://github.com/svgdotjs/svg.js/issues/1160 .

Currently, `Dom.clone()` (so `Svg.clone()`, `Container.clone()`...) assigns new IDs to cloned elements. This is usually what the user expects, since *not* assigning new IDs could lead to unexpected, hard-to-track behaviors. For example, if clones are transformed independently and displayed together, they might "share" some properties due to IDs clash.

However, when the user knows what he does, not assigning new IDs on clone can be an easy workaround to https://github.com/svgdotjs/svg.js/issues/1160 . This is because `Dom.clone()` does not update all references (eg. `fill="url(#someId)"`) when assigning new IDs.

This PR introduces a new boolean optional parameter `assignNewIds` to `Dom.clone()`:
- `true` (default): No change in behavior. Which means this PR does not break anything.
- `false`: IDs are re-used as is in the returned clone. No more broken references... but risk of ID clash.

TypeScript `.d.ts` file was updated accordingly.