### PR TITLE
added Runner.text() to swap text during animation

### DIFF
--- a/.config/karma.conf.js
+++ b/.config/karma.conf.js
@@ -10,10 +10,13 @@ if (process.platform === 'linux') {
   // in which case karma-chrome-launcher will output an error.
   // If `which` finds nothing it will throw an error.
   const { execSync } = require('child_process')
-
   try {
     if (execSync('which chromium-browser')) chromeBin = 'ChromiumHeadless'
-  } catch (e) {}
+  } catch (e) {
+    try {
+      if (execSync('which chromium')) chromeBin = 'ChromiumHeadless'
+    } catch (e) {}
+  }
 }
 
 module.exports = function (config) {
@@ -54,7 +57,6 @@ module.exports = function (config) {
           type: 'module'
         }
       ],
-
       // preprocess matching files before serving them to the browser
       // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
       preprocessors: {

--- a/spec/spec/animation/Runner.js
+++ b/spec/spec/animation/Runner.js
@@ -1,6 +1,6 @@
 /* globals describe, expect, it, beforeEach, afterEach, spyOn, jasmine */
 
-import { Runner, defaults, Ease, Controller, SVG, Timeline, Rect, Morphable, Animator, Queue, Matrix, Color, Box, Polygon, PointArray } from '../../../src/main.js'
+import { Runner, defaults, Ease, Controller, SVG, Timeline, Rect, Text, Morphable, Animator, Queue, Matrix, Color, Box, Polygon, PointArray } from '../../../src/main.js'
 import { FakeRunner, RunnerArray } from '../../../src/animation/Runner.js'
 import { getWindow } from '../../../src/utils/window.js'
 import SVGNumber from '../../../src/types/SVGNumber.js'
@@ -1767,6 +1767,31 @@ describe('Runner.js', () => {
           expect(spy).toHaveBeenCalledWith('offset', 0.5)
           expect(spy).toHaveBeenCalledWith('stop-color', '#fff')
           expect(spy).toHaveBeenCalledWith('stop-opacity', 1)
+        })
+      })
+
+      describe('text()', () => {
+        it('fails unless the runner is a text or tspan', () => {
+          const rect = new Rect(1, 2)
+          expect(() => rect.animate().text('goodbye')).toThrow('You can only animate the text of Text() objects')
+        })
+
+        it('changes the text at the half-way point', () => {
+          const element = new Text().text('hello')
+
+          const runner = element.animate(100).ease('-')
+
+          expect(element.text()).toBe('hello')
+          runner.step(49)
+          expect(element.text()).toBe('hello')
+          runner.step(1)
+          expect(element.text()).toBe('goodbye')
+          runner.step(49)
+          expect(element.text()).toBe('goodbye')
+
+          // and going backwards
+          runner.step(-80)
+          expect(element.text()).toBe('hello')
         })
       })
     })


### PR DESCRIPTION
This is more a request for review than a pull request.

I needed to be able to change text as part of the timeline (think of a counter that gets updated every second). It needs to be in a runner so that the displayed value is accurate when I scrub back and forth in the timeline.

I added the function `Runner.text()` to do this. It first checks that it is being called on a `Text` element, and then sets up a morphable from 0 to 1. In the update function, I switch between the old and new text as the morph position crosses 0.5 (in either direction). I also fade the old text down during the first half of the morph, and the new text up in the second half (again, in a reversible way).

I all seems to work fine. The reasons I suggest it might need review is:

1. It seems a little hokey updating the element in the morphable callback inside Runner. The other values are handled inside Morphable itself, but I couldn't find an obvious way to handle the fact that the animated value (the number) was not directly affecting an element's attribute.

2. I must be misunderstanding how the tests are set up, because the tests don't see the value of the text changing (but it does change IRL).

3. I haven't done any documentation changes (which I will).

Cheers


Dave