### PR TITLE
Allow strings to be passed as transform origin on TS

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -481,7 +481,7 @@ declare module "@svgdotjs/svg.js" {
         scaleY?: number
         shear?: number
         theta?: number
-        origin?: CoordinateXY
+        origin?: CoordinateXY | string
         around?: CoordinateXY
         ox?: number
         originX?: number


### PR DESCRIPTION
We need this to be able to pass strings like "top-right" or "center" as transform origin on TypeScript, as they're already supported on JavaScript.

@neomorfeo