### PR TITLE
fix arc flags parsing

### DIFF
--- a/spec/spec/utils/pathParser.js
+++ b/spec/spec/utils/pathParser.js
@@ -102,6 +102,32 @@ describe('pathParser.js', () => {
         [ 'L', 0.3, 0.3 ],
         [ 'Z' ]
       ])
+
+      // "a" commands without optional whitespace around the flag params
+      expect(pathParser('a32 32 0 00.03-45.22', false)).toEqual([
+        [ 'a', 32.0, 32.0, 0.0, 0.0, 0.0, 0.03, -45.22 ],
+      ])
+
+      expect(pathParser('a48 48 0 1148-48', false)).toEqual([
+        [ 'a', 48.0, 48.0, 0.0, 1.0, 1.0, 48.0, -48.0],
+      ])
+
+      expect(pathParser('a82.6 82.6 0 0033.48-20.25', false)).toEqual([
+        [ 'a', 82.6, 82.6, 0.0, 0.0, 0.0, 33.48, -20.25 ],
+      ])
+
+      expect(pathParser('a82.45 82.45 0 00-20.24 33.47', false)).toEqual([
+        [ 'a', 82.45, 82.45, 0.0, 0.0, 0.0, -20.24, 33.47 ],
+      ])
+
+      expect(pathParser('a2.51 2.51 0 01.25.32', false)).toEqual([
+        [ 'a', 2.51, 2.51, 0, 0, 1, 0.25, 0.32 ],
+      ])
+
+      expect(pathParser('a48 48 0 1148-48 48 48 0 01-48 48', false)).toEqual([
+        [ 'a', 48.0, 48.0, 0.0, 1.0, 1.0, 48.0, -48.0 ],
+        [ 'a', 48.0, 48.0, 0.0, 0.0, 1.0, -48.0, 48.0 ]
+      ])
     })
   })
 })

--- a/spec/spec/utils/pathParser.js
+++ b/spec/spec/utils/pathParser.js
@@ -103,7 +103,7 @@ describe('pathParser.js', () => {
         [ 'Z' ]
       ])
 
-      // "a" commands without optional whitespace around the flag params
+      // "a" commands without optional whitespace around the flag params and ending coordinate pair
       expect(pathParser('a32 32 0 00.03-45.22', false)).toEqual([
         [ 'a', 32.0, 32.0, 0.0, 0.0, 0.0, 0.03, -45.22 ],
       ])
@@ -122,6 +122,14 @@ describe('pathParser.js', () => {
 
       expect(pathParser('a2.51 2.51 0 01.25.32', false)).toEqual([
         [ 'a', 2.51, 2.51, 0, 0, 1, 0.25, 0.32 ],
+      ])
+
+      expect(pathParser('a2.51 2.51 0 00.25.32', false)).toEqual([
+        [ 'a', 2.51, 2.51, 0, 0, 0, 0.25, 0.32 ],
+      ])
+
+      expect(pathParser('a2.51 2.51 0 000.25.32', false)).toEqual([
+        [ 'a', 2.51, 2.51, 0, 0, 0, 0.25, 0.32 ],
       ])
 
       expect(pathParser('a48 48 0 1148-48 48 48 0 01-48 48', false)).toEqual([

--- a/src/utils/pathParser.js
+++ b/src/utils/pathParser.js
@@ -176,8 +176,11 @@ export function pathParser (d, toAbsolute = true) {
 
     if (!isNaN(parseInt(token))) {
 
-      if (parser.number === '0' || (parser.inNumber && isArcFlag(parser))) {
+      if (parser.number === '0' || isArcFlag(parser)) {
+        parser.inNumber = true
+        parser.number = token
         finalizeNumber(parser, true)
+        continue
       }
 
       parser.inNumber = true


### PR DESCRIPTION
This PR proposes a fix for parsing Elliptical Arc commands in SVG paths. The parser has been failing to parse some valid arc commands. For example, the [grammar](https://www.w3.org/TR/SVG/paths.html#PathDataBNF) allows for whitespace/comma to be omitted following one of the arc flags.