### PR TITLE
fix: lowerCase the nodeName of the dom node first

### DIFF
--- a/src/utils/adopter.js
+++ b/src/utils/adopter.js
@@ -58,7 +58,7 @@ export function adopt (node) {
   }
 
   // initialize variables
-  let className = capitalize(node.nodeName || 'Dom')
+  let className = capitalize((node.nodeName || 'Dom').toLowerCase());
 
   // Make sure that gradients are adopted correctly
   if (className === 'LinearGradient' || className === 'RadialGradient') {


### PR DESCRIPTION
when referencing existing DOM elements, there are bugs as the nodeName of the DOM node is uppercase