### PR TITLE
Adds dmove to type definition for class Runner

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -881,6 +881,7 @@ declare module "@svgdotjs/svg.js" {
         dy(dy: number): this
         cx(x: number): this
         cy(y: number): this
+        dmove(dx: number, dy: number): this
         move(x: number, y: number): this
         center(x: number, y: number): this
         size(width: number, height: number): this


### PR DESCRIPTION
Current typings for `Runner` do not include the `dmove` method defined [here](https://github.com/svgdotjs/svg.js/blob/master/src/animation/Runner.js#L885). This PR adds that definition.

Created #1232 for this PR.