### PR TITLE
Fix #1235

### DIFF
--- a/spec/spec/elements/Element.js
+++ b/spec/spec/elements/Element.js
@@ -188,6 +188,20 @@ describe('Element.js', function () {
       expect(rect.parents('.foo')).toEqual([ group3 ])
       expect(rect.parents('.test:not(.foo)')).toEqual([ group3, group2, group1 ])
     })
+
+    it('returns null if the passed element is not an ancestor', () => {
+      const canvas = SVG().addTo(container)
+      const groupA = canvas.group().addClass('test')
+      const group1 = canvas.group()
+      const group2 = group1.group()
+      const group3 = group2.group()
+      const rect = group3.rect(100, 100)
+
+
+      expect(rect.parents('.does-not-exist')).toEqual(null)
+      expect(rect.parents('.test')).toEqual(null)
+      expect(rect.parents(groupA)).toEqual(null)
+    })
   })
 
   describe('reference()', () => {

--- a/spec/spec/elements/Element.js
+++ b/spec/spec/elements/Element.js
@@ -175,6 +175,19 @@ describe('Element.js', function () {
       expect(rect.parents(group1).length).toBe(3)
       expect(rect.parents()).toEqual([ group3, group2, group1, canvas ])
     })
+
+    it('returns array of parents until the closest matching parent', () => {
+      const canvas = SVG().addTo(container)
+      const groupA = canvas.group().addClass('test')
+      const group1 = canvas.group().addClass('test')
+      const group2 = group1.group().addClass('test').addClass('foo')
+      const group3 = group2.group().addClass('foo')
+      const rect = group3.rect(100, 100)
+
+      expect(rect.parents('.test')).toEqual([ group3, group2 ])
+      expect(rect.parents('.foo')).toEqual([ group3 ])
+      expect(rect.parents('.test:not(.foo)')).toEqual([ group3, group2, group1 ])
+    })
   })
 
   describe('reference()', () => {

--- a/spec/spec/elements/Element.js
+++ b/spec/spec/elements/Element.js
@@ -165,6 +165,7 @@ describe('Element.js', function () {
   describe('parents()', () => {
     it('returns array of parents until the passed element or root svg', () => {
       const canvas = SVG().addTo(container)
+      const groupA = canvas.group().addClass('test')
       const group1 = canvas.group().addClass('test')
       const group2 = group1.group()
       const group3 = group2.group()

--- a/src/elements/Element.js
+++ b/src/elements/Element.js
@@ -87,7 +87,13 @@ export default class Element extends Dom {
 
   // return array of all ancestors of given type up to the root svg
   parents (until = this.root()) {
-    until = makeInstance(until)
+    let selector = null
+    if (typeof until === 'string') {
+      selector = until
+      until = this.root()
+    } else {
+      until = makeInstance(until)
+    }
     const parents = new List()
     let parent = this
 
@@ -99,6 +105,9 @@ export default class Element extends Dom {
       parents.push(parent)
 
       if (parent.node === until.node) {
+        break
+      }
+      if (selector && parent.matches(selector)) {
         break
       }
     }

--- a/src/elements/Element.js
+++ b/src/elements/Element.js
@@ -87,11 +87,8 @@ export default class Element extends Dom {
 
   // return array of all ancestors of given type up to the root svg
   parents (until = this.root()) {
-    let selector = null
-    if (typeof until === 'string') {
-      selector = until
-      until = this.root()
-    } else {
+    const isSelector = typeof until === 'string'
+    if (!isSelector) {
       until = makeInstance(until)
     }
     const parents = new List()
@@ -104,11 +101,15 @@ export default class Element extends Dom {
 
       parents.push(parent)
 
-      if (parent.node === until.node) {
+      if (!isSelector && (parent.node === until.node)) {
         break
       }
-      if (selector && parent.matches(selector)) {
+      if (isSelector && parent.matches(until)) {
         break
+      }
+      if (parent.node === this.root().node) {
+        // We worked our way to the root and didn't match `until`
+        return null
       }
     }
 


### PR DESCRIPTION
Fixes the bugs in `Element.parents()` function.

This also introduces a minor change to functionality, but it's a change that previously threw a TypeError, so I don't think it can be considered a "breaking change". It's also more-or-less what the docs say this function does, although they're not specific.

**This function no longer searches outside the containing SVG document; if it reaches `this.root()` without finding a matching element, it returns `null`.**

This is, I think, what most devs would expect. If I call `parents('.foo')`, I expect the last element in that array to have the class `foo`. I'm confident most devs would agree.