### PR TITLE
Performance: don't create a double clone in point

### DIFF
--- a/src/types/Point.js
+++ b/src/types/Point.js
@@ -54,5 +54,5 @@ export default class Point {
 }
 
 export function point (x, y) {
-  return new Point(x, y).transform(this.screenCTM().inverse())
+  return new Point(x, y).transform0(this.screenCTM().inverse())
 }

--- a/src/types/Point.js
+++ b/src/types/Point.js
@@ -54,5 +54,5 @@ export default class Point {
 }
 
 export function point (x, y) {
-  return new Point(x, y).transform0(this.screenCTM().inverse())
+  return new Point(x, y).transformO(this.screenCTM().inverse())
 }

--- a/src/types/Point.js
+++ b/src/types/Point.js
@@ -54,5 +54,5 @@ export default class Point {
 }
 
 export function point (x, y) {
-  return new Point(x, y).transformO(this.screenCTM().inverse())
+  return new Point(x, y).transformO(this.screenCTM().inverseO())
 }


### PR DESCRIPTION
The Point instance is already created, so don't create a new one.

Edit: also don't clone the newly created Matrix from `getScreenCTM`