### PR TITLE
fix: Don't same variable name as variable function

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/src/animation/Morphable.js
+++ b/src/animation/Morphable.js
@@ -72,9 +72,9 @@ export default class Morphable {
     return this
   }
 
-  stepper (stepper) {
-    if (stepper == null) return this._stepper
-    this._stepper = stepper
+  stepper (stepperValue) {
+    if (stepperValue == null) return this._stepper
+    this._stepper = stepperValue
     return this
   }
 
@@ -87,14 +87,14 @@ export default class Morphable {
     return this
   }
 
-  type (type) {
+  type (typeValue) {
     // getter
-    if (type == null) {
+    if (typeValue == null) {
       return this._type
     }
 
     // setter
-    this._type = type
+    this._type = typeValue
     return this
   }
 

--- a/src/animation/Runner.js
+++ b/src/animation/Runner.js
@@ -142,8 +142,8 @@ export default class Runner extends EventTarget {
     }
   }
 
-  delay (delay) {
-    return this.animate(0, delay)
+  delay (delayValue) {
+    return this.animate(0, delayValue)
   }
 
   duration () {
@@ -165,10 +165,10 @@ export default class Runner extends EventTarget {
   help us make new runners from the current runner
   */
 
-  element (element) {
-    if (element == null) return this._element
-    this._element = element
-    element._prepareRunner()
+  element (elementValue) {
+    if (elementValue == null) return this._element
+    this._element = elementValue
+    elementValue._prepareRunner()
     return this
   }
 
@@ -293,8 +293,8 @@ export default class Runner extends EventTarget {
     return this
   }
 
-  reverse (reverse) {
-    this._reverse = reverse == null ? !this._reverse : reverse
+  reverse (reverseValue) {
+    this._reverse = reverseValue == null ? !this._reverse : reverseValue
     return this
   }
 
@@ -373,19 +373,19 @@ export default class Runner extends EventTarget {
   ========================
   Control how the animation plays
   */
-  time (time) {
-    if (time == null) {
+  time (timeValue) {
+    if (timeValue == null) {
       return this._time
     }
-    const dt = time - this._time
+    const dt = timeValue - this._time
     this.step(dt)
     return this
   }
 
-  timeline (timeline) {
+  timeline (timelineValue) {
     // check explicitly for undefined so we can set the timeline to null
-    if (typeof timeline === 'undefined') return this._timeline
-    this._timeline = timeline
+    if (typeof timelineValue === 'undefined') return this._timeline
+    this._timeline = timelineValue
     return this
   }
 
@@ -865,13 +865,13 @@ extend(Runner, {
   },
 
   // Animatable x-axis
-  x (x, relative) {
-    return this._queueNumber('x', x)
+  x (xValue, relative) {
+    return this._queueNumber('x', xValue)
   },
 
   // Animatable y-axis
-  y (y) {
-    return this._queueNumber('y', y)
+  y (yValue) {
+    return this._queueNumber('y', yValue)
   },
 
   dx (x = 0) {
@@ -976,13 +976,13 @@ extend(Runner, {
   },
 
   // Add animatable width
-  width (width) {
-    return this._queueNumber('width', width)
+  width (widthValue) {
+    return this._queueNumber('width', widthValue)
   },
 
   // Add animatable height
-  height (height) {
-    return this._queueNumber('height', height)
+  height (heightValue) {
+    return this._queueNumber('height', heightValue)
   },
 
   // Add animatable plot

--- a/src/animation/Timeline.js
+++ b/src/animation/Timeline.js
@@ -168,9 +168,9 @@ export default class Timeline extends EventTarget {
     return this
   }
 
-  speed (speed) {
-    if (speed == null) return this._speed
-    this._speed = speed
+  speed (speedValue) {
+    if (speedValue == null) return this._speed
+    this._speed = speedValue
     return this
   }
 
@@ -180,9 +180,9 @@ export default class Timeline extends EventTarget {
     return this.pause()
   }
 
-  time (time) {
-    if (time == null) return this._time
-    this._time = time
+  time (timeValue) {
+    if (timeValue == null) return this._time
+    this._time = timeValue
     return this._continue(true)
   }
 

--- a/src/elements/A.js
+++ b/src/elements/A.js
@@ -10,8 +10,8 @@ export default class A extends Container {
   }
 
   // Link target attribute
-  target (target) {
-    return this.attr('target', target)
+  target (targetValue) {
+    return this.attr('target', targetValue)
   }
 
   // Link url

--- a/src/elements/Circle.js
+++ b/src/elements/Circle.js
@@ -19,17 +19,17 @@ export default class Circle extends Shape {
   }
 
   // Radius x value
-  rx (rx) {
-    return this.attr('r', rx)
+  rx (rxValue) {
+    return this.attr('r', rxValue)
   }
 
   // Alias radius x value
-  ry (ry) {
-    return this.rx(ry)
+  ry (ryValue) {
+    return this.rx(ryValue)
   }
 
-  size (size) {
-    return this.radius(new SVGNumber(size).divide(2))
+  size (sizeValue) {
+    return this.radius(new SVGNumber(sizeValue).divide(2))
   }
 }
 

--- a/src/elements/Dom.js
+++ b/src/elements/Dom.js
@@ -123,14 +123,14 @@ export default class Dom extends EventTarget {
   }
 
   // Get / set id
-  id (id) {
+  id (idValue) {
     // generate new id if no id set
-    if (typeof id === 'undefined' && !this.node.id) {
+    if (typeof idValue === 'undefined' && !this.node.id) {
       this.node.id = eid(this.type)
     }
 
     // don't set directly with this.node.id to make `null` work correctly
-    return this.attr('id', id)
+    return this.attr('id', idValue)
   }
 
   // Gets index of given element

--- a/src/elements/Element.js
+++ b/src/elements/Element.js
@@ -76,8 +76,8 @@ export default class Element extends Dom {
   }
 
   // Set height of element
-  height (height) {
-    return this.attr('height', height)
+  height (heightValue) {
+    return this.attr('height', heightValue)
   }
 
   // Move element to given x and y values
@@ -147,8 +147,8 @@ export default class Element extends Dom {
   }
 
   // Set width of element
-  width (width) {
-    return this.attr('width', width)
+  width (widthValue) {
+    return this.attr('width', widthValue)
   }
 
   // write svgjs data to the dom
@@ -164,13 +164,13 @@ export default class Element extends Dom {
   }
 
   // Move over x-axis
-  x (x) {
-    return this.attr('x', x)
+  x (xValue) {
+    return this.attr('x', xValue)
   }
 
   // Move over y-axis
-  y (y) {
-    return this.attr('y', y)
+  y (yValue) {
+    return this.attr('y', yValue)
   }
 }
 

--- a/src/elements/Marker.js
+++ b/src/elements/Marker.js
@@ -9,12 +9,12 @@ export default class Marker extends Container {
   }
 
   // Set height of element
-  height (height) {
-    return this.attr('markerHeight', height)
+  height (heightValue) {
+    return this.attr('markerHeight', heightValue)
   }
 
-  orient (orient) {
-    return this.attr('orient', orient)
+  orient (orientValue) {
+    return this.attr('orient', orientValue)
   }
 
   // Set marker refX and refY
@@ -41,8 +41,8 @@ export default class Marker extends Container {
   }
 
   // Set width of element
-  width (width) {
-    return this.attr('markerWidth', width)
+  width (widthValue) {
+    return this.attr('markerWidth', widthValue)
   }
 
 }
@@ -68,19 +68,19 @@ registerMethods({
   },
   marker: {
     // Create and attach markers
-    marker (marker, width, height, block) {
+    marker (markerValue, width, height, block) {
       let attr = [ 'marker' ]
 
       // Build attribute name
-      if (marker !== 'all') attr.push(marker)
+      if (markerValue !== 'all') attr.push(markerValue)
       attr = attr.join('-')
 
       // Set marker attribute
-      marker = arguments[1] instanceof Marker
+      markerValue = arguments[1] instanceof Marker
         ? arguments[1]
         : this.defs().marker(width, height, block)
 
-      return this.attr(attr, marker)
+      return this.attr(attr, markerValue)
     }
   }
 })

--- a/src/elements/Path.js
+++ b/src/elements/Path.js
@@ -22,8 +22,8 @@ export default class Path extends Shape {
   }
 
   // Set height of element
-  height (height) {
-    return height == null ? this.bbox().height : this.size(this.bbox().width, height)
+  height (heightValue) {
+    return heightValue == null ? this.bbox().height : this.size(this.bbox().width, heightValue)
   }
 
   // Move by left top corner
@@ -45,18 +45,18 @@ export default class Path extends Shape {
   }
 
   // Set width of element
-  width (width) {
-    return width == null ? this.bbox().width : this.size(width, this.bbox().height)
+  width (widthValue) {
+    return widthValue == null ? this.bbox().width : this.size(widthValue, this.bbox().height)
   }
 
   // Move by left top corner over x-axis
-  x (x) {
-    return x == null ? this.bbox().x : this.move(x, this.bbox().y)
+  x (xValue) {
+    return xValue == null ? this.bbox().x : this.move(xValue, this.bbox().y)
   }
 
   // Move by left top corner over y-axis
-  y (y) {
-    return y == null ? this.bbox().y : this.move(this.bbox().x, y)
+  y (yValue) {
+    return yValue == null ? this.bbox().y : this.move(this.bbox().x, yValue)
   }
 
 }

--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -35,10 +35,10 @@ export default class Text extends Shape {
   }
 
   // Rebuild appearance type
-  rebuild (rebuild) {
+  rebuild (rebuildValue) {
     // store new rebuild flag if given
-    if (typeof rebuild === 'boolean') {
-      this._rebuild = rebuild
+    if (typeof rebuildValue === 'boolean') {
+      this._rebuild = rebuildValue
     }
 
     // define position of all lines
@@ -79,12 +79,12 @@ export default class Text extends Shape {
   }
 
   // Set the text content
-  text (text) {
+  text (textValue) {
     // act as getter
-    if (text === undefined) {
+    if (textValue === undefined) {
       const children = this.node.childNodes
       let firstLine = 0
-      text = ''
+      textValue = ''
 
       for (let i = 0, len = children.length; i < len; ++i) {
         // skip textPaths - they are no lines
@@ -95,29 +95,29 @@ export default class Text extends Shape {
 
         // add newline if its not the first child and newLined is set to true
         if (i !== firstLine && children[i].nodeType !== 3 && adopt(children[i]).dom.newLined === true) {
-          text += '\n'
+          textValue += '\n'
         }
 
         // add content of this node
-        text += children[i].textContent
+        textValue += children[i].textContent
       }
 
-      return text
+      return textValue
     }
 
     // remove existing content
     this.clear().build(true)
 
-    if (typeof text === 'function') {
+    if (typeof textValue === 'function') {
       // call block
-      text.call(this, this)
+      textValue.call(this, this)
     } else {
       // store text and make sure text is not blank
-      text = (text + '').split('\n')
+      textValue = (textValue + '').split('\n')
 
       // build new lines
-      for (let j = 0, jl = text.length; j < jl; j++) {
-        this.newLine(text[j])
+      for (let j = 0, jl = textValue.length; j < jl; j++) {
+        this.newLine(textValue[j])
       }
     }
 

--- a/src/elements/Tspan.js
+++ b/src/elements/Tspan.js
@@ -19,13 +19,13 @@ export default class Tspan extends Shape {
   }
 
   // Shortcut dx
-  dx (dx) {
-    return this.attr('dx', dx)
+  dx (dxValue) {
+    return this.attr('dx', dxValue)
   }
 
   // Shortcut dy
-  dy (dy) {
-    return this.attr('dy', dy)
+  dy (dyValue) {
+    return this.attr('dy', dyValue)
   }
 
   // Create new line
@@ -52,15 +52,15 @@ export default class Tspan extends Shape {
   }
 
   // Set text content
-  text (text) {
-    if (text == null) return this.node.textContent + (this.dom.newLined ? '\n' : '')
+  text (textValue) {
+    if (textValue == null) return this.node.textContent + (this.dom.newLined ? '\n' : '')
 
-    if (typeof text === 'function') {
+    if (typeof textValue === 'function') {
       this.clear().build(true)
-      text.call(this, this)
+      textValue.call(this, this)
       this.build(false)
     } else {
-      this.plain(text)
+      this.plain(textValue)
     }
 
     return this

--- a/src/modules/core/attr.js
+++ b/src/modules/core/attr.js
@@ -10,44 +10,44 @@ export function registerAttrHook (fn) {
 }
 
 // Set svg element attribute
-export default function attr (attr, val, ns) {
+export default function attr (attrValue, val, ns) {
   // act as full getter
-  if (attr == null) {
+  if (attrValue == null) {
     // get an object of attributes
-    attr = {}
+    attrValue = {}
     val = this.node.attributes
 
     for (const node of val) {
-      attr[node.nodeName] = isNumber.test(node.nodeValue)
+      attrValue[node.nodeName] = isNumber.test(node.nodeValue)
         ? parseFloat(node.nodeValue)
         : node.nodeValue
     }
 
-    return attr
-  } else if (attr instanceof Array) {
+    return attrValue
+  } else if (attrValue instanceof Array) {
     // loop through array and get all values
-    return attr.reduce((last, curr) => {
+    return attrValue.reduce((last, curr) => {
       last[curr] = this.attr(curr)
       return last
     }, {})
-  } else if (typeof attr === 'object' && attr.constructor === Object) {
+  } else if (typeof attrValue === 'object' && attrValue.constructor === Object) {
     // apply every attribute individually if an object is passed
-    for (val in attr) this.attr(val, attr[val])
+    for (val in attrValue) this.attr(val, attrValue[val])
   } else if (val === null) {
     // remove value
-    this.node.removeAttribute(attr)
+    this.node.removeAttribute(attrValue)
   } else if (val == null) {
     // act as a getter if the first and only argument is not an object
-    val = this.node.getAttribute(attr)
+    val = this.node.getAttribute(attrValue)
     return val == null
-      ? defaults[attr]
+      ? defaults[attrValue]
       : isNumber.test(val)
         ? parseFloat(val)
         : val
   } else {
     // Loop through hooks and execute them to convert value
     val = hooks.reduce((_val, hook) => {
-      return hook(attr, _val, this)
+      return hook(attrValue, _val, this)
     }, val)
 
     // ensure correct numeric values (also accepts NaN and Infinity)
@@ -62,7 +62,7 @@ export default function attr (attr, val, ns) {
     }
 
     // if the passed attribute is leading...
-    if (attr === 'leading') {
+    if (attrValue === 'leading') {
       // ... call the leading method instead
       if (this.leading) {
         this.leading(val)
@@ -70,12 +70,12 @@ export default function attr (attr, val, ns) {
     } else {
       // set given attribute on node
       typeof ns === 'string'
-        ? this.node.setAttributeNS(ns, attr, val.toString())
-        : this.node.setAttribute(attr, val.toString())
+        ? this.node.setAttributeNS(ns, attrValue, val.toString())
+        : this.node.setAttribute(attrValue, val.toString())
     }
 
     // rebuild if required
-    if (this.rebuild && (attr === 'font-size' || attr === 'x')) {
+    if (this.rebuild && (attrValue === 'font-size' || attrValue === 'x')) {
       this.rebuild()
     }
   }

--- a/src/modules/core/circled.js
+++ b/src/modules/core/circled.js
@@ -1,27 +1,27 @@
 import SVGNumber from '../../types/SVGNumber.js'
 
 // Radius x value
-export function rx (rx) {
-  return this.attr('rx', rx)
+export function rx (rxValue) {
+  return this.attr('rx', rxValue)
 }
 
 // Radius y value
-export function ry (ry) {
-  return this.attr('ry', ry)
+export function ry (ryValue) {
+  return this.attr('ry', ryValue)
 }
 
 // Move over x-axis
-export function x (x) {
-  return x == null
+export function x (xValue) {
+  return xValue == null
     ? this.cx() - this.rx()
-    : this.cx(x + this.rx())
+    : this.cx(xValue + this.rx())
 }
 
 // Move over y-axis
-export function y (y) {
-  return y == null
+export function y (yValue) {
+  return yValue == null
     ? this.cy() - this.ry()
-    : this.cy(y + this.ry())
+    : this.cy(yValue + this.ry())
 }
 
 // Move by center over x-axis
@@ -35,15 +35,15 @@ export function cy (y) {
 }
 
 // Set width of element
-export function width (width) {
-  return width == null
+export function width (widthValue) {
+  return widthValue == null
     ? this.rx() * 2
-    : this.rx(new SVGNumber(width).divide(2))
+    : this.rx(new SVGNumber(widthValue).divide(2))
 }
 
 // Set height of element
-export function height (height) {
-  return height == null
+export function height (heightValue) {
+  return heightValue == null
     ? this.ry() * 2
-    : this.ry(new SVGNumber(height).divide(2))
+    : this.ry(new SVGNumber(heightValue).divide(2))
 }

--- a/src/modules/core/containerGeometry.js
+++ b/src/modules/core/containerGeometry.js
@@ -30,17 +30,17 @@ export function dmove (dx, dy) {
   return this
 }
 
-export function dx (dx) {
-  return this.dmove(dx, 0)
+export function dx (dxValue) {
+  return this.dmove(dxValue, 0)
 }
 
-export function dy (dy) {
-  return this.dmove(0, dy)
+export function dy (dyValue) {
+  return this.dmove(0, dyValue)
 }
 
-export function height (height, box = this.bbox()) {
-  if (height == null) return box.height
-  return this.size(box.width, height, box)
+export function height (heightValue, box = this.bbox()) {
+  if (heightValue == null) return box.height
+  return this.size(box.width, heightValue, box)
 }
 
 export function move (x = 0, y = 0, box = this.bbox()) {
@@ -63,17 +63,17 @@ export function size (width, height, box = this.bbox()) {
   return this
 }
 
-export function width (width, box = this.bbox()) {
-  if (width == null) return box.width
-  return this.size(width, box.height, box)
+export function width (widthValue, box = this.bbox()) {
+  if (widthValue == null) return box.width
+  return this.size(widthValue, box.height, box)
 }
 
-export function x (x, box = this.bbox()) {
-  if (x == null) return box.x
-  return this.move(x, box.y, box)
+export function x (xValue, box = this.bbox()) {
+  if (xValue == null) return box.x
+  return this.move(xValue, box.y, box)
 }
 
-export function y (y, box = this.bbox()) {
-  if (y == null) return box.y
-  return this.move(box.x, y, box)
+export function y (yValue, box = this.bbox()) {
+  if (yValue == null) return box.y
+  return this.move(box.x, yValue, box)
 }

--- a/src/modules/core/pointed.js
+++ b/src/modules/core/pointed.js
@@ -3,23 +3,23 @@ import PointArray from '../../types/PointArray.js'
 export const MorphArray = PointArray
 
 // Move by left top corner over x-axis
-export function x (x) {
-  return x == null ? this.bbox().x : this.move(x, this.bbox().y)
+export function x (xValue) {
+  return xValue == null ? this.bbox().x : this.move(xValue, this.bbox().y)
 }
 
 // Move by left top corner over y-axis
-export function y (y) {
-  return y == null ? this.bbox().y : this.move(this.bbox().x, y)
+export function y (yValue) {
+  return yValue == null ? this.bbox().y : this.move(this.bbox().x, yValue)
 }
 
 // Set width of element
-export function width (width) {
+export function width (widthValue) {
   const b = this.bbox()
-  return width == null ? b.width : this.size(width, b.height)
+  return widthValue == null ? b.width : this.size(widthValue, b.height)
 }
 
 // Set height of element
-export function height (height) {
+export function height (heightValue) {
   const b = this.bbox()
-  return height == null ? b.height : this.size(b.width, height)
+  return heightValue == null ? b.height : this.size(b.width, heightValue)
 }

--- a/src/modules/core/textable.js
+++ b/src/modules/core/textable.js
@@ -21,21 +21,21 @@ export function length () {
 // Move over x-axis
 // Text is moved by its bounding box
 // text-anchor does NOT matter
-export function x (x, box = this.bbox()) {
-  if (x == null) {
+export function x (xValue, box = this.bbox()) {
+  if (xValue == null) {
     return box.x
   }
 
-  return this.attr('x', this.attr('x') + x - box.x)
+  return this.attr('x', this.attr('x') + xValue - box.x)
 }
 
 // Move over y-axis
-export function y (y, box = this.bbox()) {
-  if (y == null) {
+export function y (yValue, box = this.bbox()) {
+  if (yValue == null) {
     return box.y
   }
 
-  return this.attr('y', this.attr('y') + y - box.y)
+  return this.attr('y', this.attr('y') + yValue - box.y)
 }
 
 export function move (x, y, box = this.bbox()) {
@@ -77,7 +77,7 @@ export function amove (x, y) {
 }
 
 // Enable / disable build mode
-export function build (build) {
-  this._build = !!build
+export function build (buildValue) {
+  this._build = !!buildValue
   return this
 }


### PR DESCRIPTION
When using this library in Safari (OsX or iPad) we may encounter the error:

'duplicate parameter in function with default parameter values'

This is related to the use of a variable name that is the same as the function and similar fix were applied in other libraries like:
https://github.com/jupyterlab/jupyterlab/pull/7993/files