### PR TITLE
docs: Fix a few typos

### DIFF
--- a/spec/spec/animation/Runner.js
+++ b/spec/spec/animation/Runner.js
@@ -915,7 +915,7 @@ describe('Runner.js', () => {
         it('throws away the morpher if it wasnt initialized yet and returns false', () => {
           const rect = new Rect().move(0, 0)
           const runner = rect.animate().move(10, 10)
-          // In that case tryRetarget is not successfull
+          // In that case tryRetarget is not successful
           expect(runner._tryRetarget('x', 20)).toBe(false)
         })
 
@@ -923,7 +923,7 @@ describe('Runner.js', () => {
           const rect = new Rect().move(0, 0)
           const runner = rect.animate().move(10, 10)
           jasmine.RequestAnimationFrame.tick(16)
-          // In that case tryRetarget is not successfull
+          // In that case tryRetarget is not successful
           expect(runner._tryRetarget('foo', 20)).toBe(false)
         })
 
@@ -931,11 +931,11 @@ describe('Runner.js', () => {
           const rect = new Rect()
           const runner = rect.animate(new Controller(() => 0)).transform({ translate: [ 10, 10 ] })
           jasmine.RequestAnimationFrame.tick(16)
-          // In that case tryRetarget is not successfull
+          // In that case tryRetarget is not successful
           expect(runner._tryRetarget('transform', { translate: [ 20, 20 ] })).toBe(true)
         })
 
-        it('starts the timeline if retarget was successfull', () => {
+        it('starts the timeline if retarget was successful', () => {
           const timeline = new Timeline()
           const rect = new Rect().move(0, 0).timeline(timeline)
           const runner = rect.animate().move(10, 10)
@@ -1334,7 +1334,7 @@ describe('Runner.js', () => {
           runner.transform({ translate: [ 10, 20 ], scale: 2, rotate: 90 })
           runner.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
           expect(element.matrix().decompose()).toEqual(objectContaining({
             translateX: 5,
@@ -1385,7 +1385,7 @@ describe('Runner.js', () => {
           runner.translate(10, 20).scale(2).rotate(45)
           runner.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
 
           // The origin is transformed with every
@@ -1406,7 +1406,7 @@ describe('Runner.js', () => {
           runner2.step(50)
           runner3.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
 
           // The origin is transformed with every
@@ -1427,7 +1427,7 @@ describe('Runner.js', () => {
           runner2.step(50)
           runner3.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
 
           expect(runner1._queue.length).toBe(0)
@@ -1444,7 +1444,7 @@ describe('Runner.js', () => {
           runner.transform(new Matrix({ rotate: 90 }))
           runner.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
 
           // The origin is transformed with every
@@ -1459,7 +1459,7 @@ describe('Runner.js', () => {
           runner.transform(Object.assign({ affine: true }, new Matrix({ rotate: 90 })))
           runner.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
 
           // The origin is transformed with every
@@ -1474,7 +1474,7 @@ describe('Runner.js', () => {
           runner.transform(new Matrix({ rotate: 90 }), true, true)
           runner.step(50)
           // transform sets an immediate callback to apply all merged transforms
-          // when every runner had the chance to add its bit of tranforms
+          // when every runner had the chance to add its bit of transforms
           jasmine.RequestAnimationFrame.tick(1)
 
           // The origin is transformed with every

--- a/src/animation/Runner.js
+++ b/src/animation/Runner.js
@@ -360,7 +360,7 @@ export default class Runner extends EventTarget {
       this.fire('step', this)
     }
     // correct the done flag here
-    // declaritive animations itself know when they converged
+    // declarative animations itself know when they converged
     this.done = this.done || (converged && declarative)
     if (justFinished) {
       this.fire('finished', this)
@@ -619,7 +619,7 @@ registerMethods({
 
     // this function searches for all runners on the element and deletes the ones
     // which run before the current one. This is because absolute transformations
-    // overwfrite anything anyway so there is no need to waste time computing
+    // overwrite anything anyway so there is no need to waste time computing
     // other runners
     _clearTransformRunnersBefore (currentRunner) {
       this._transformationRunners.clearBefore(currentRunner.id)
@@ -769,7 +769,7 @@ extend(Runner, {
       ? transforms.affine
       : (affine != null ? affine : !isMatrix)
 
-    // Create a morepher and set its type
+    // Create a morpher and set its type
     const morpher = new Morphable(this._stepper)
       .type(affine ? TransformBag : Matrix)
 

--- a/src/animation/Timeline.js
+++ b/src/animation/Timeline.js
@@ -243,12 +243,12 @@ export default class Timeline extends EventTarget {
     // the runner to position 0
 
     // FIXME:
-    // However, reseting in insertion order leads to bugs. Considering the case,
+    // However, resetting in insertion order leads to bugs. Considering the case,
     // where 2 runners change the same attribute but in different times,
-    // reseting both of them will lead to the case where the later defined
+    // resetting both of them will lead to the case where the later defined
     // runner always wins the reset even if the other runner started earlier
     // and therefore should win the attribute battle
-    // this can be solved by reseting them backwards
+    // this can be solved by resetting them backwards
     for (let k = this._runners.length; k--;) {
       // Get and run the current runner and ignore it if its inactive
       const runnerInfo = this._runners[k]


### PR DESCRIPTION
There are small typos in:
- spec/spec/animation/Runner.js
- src/animation/Runner.js
- src/animation/Timeline.js

Fixes:
- Should read `successful` rather than `successfull`.
- Should read `transforms` rather than `tranforms`.
- Should read `resetting` rather than `reseting`.
- Should read `overwrite` rather than `overwfrite`.
- Should read `morpher` rather than `morepher`.
- Should read `declarative` rather than `declaritive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md