### PR TITLE
fix: reorder 'default' export condition to the end for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./src/main.js",
-        "types": "./svg.js.d.ts"
+        "types": "./svg.js.d.ts",
+        "default": "./src/main.js"
       },
       "require": {
-        "default": "./dist/svg.node.cjs",
-        "types": "./svg.js.d.ts"
+        "types": "./svg.js.d.ts",
+        "default": "./dist/svg.node.cjs"
       }
     }
   },


### PR DESCRIPTION
> From ChatGPT

This PR addresses an issue with the `package.json` where the `default` export condition was not listed as the final entry in the `exports` field. While the ECMAScript specification indicates that object keys are unordered, some build tools have come to rely on the order of export conditions to function correctly. By moving the `default` condition to the last position, we can improve the compatibility of this package with a wider variety of build tools and environments that may depend on this ordering.

#### Changes made:
- Reordered the `default` export condition within the `.exports` field of `package.json` to appear last for both `import` and `require` conditions.

#### Benefits:
- Increases predictability and compatibility with build tools that may rely on the ordering of conditions in the `exports` field.
- Aligns with community best practices for defining fallback export conditions in `package.json`.

Please review the changes and merge this PR if everything is in order. Thank you for considering this improvement to the package's build tool compatibility.

#### Additional Context (if any):
- Provide links to discussions or documentation about the build tools that have this ordering dependency, if available.
- Mention specific issues this PR might resolve, or why this change was necessary based on feedback or reported problems.
