### PR TITLE
Remove gbox() from G in svg.js.d.ts

### DIFF
--- a/svg.js.d.ts
+++ b/svg.js.d.ts
@@ -1677,7 +1677,6 @@ declare module '@svgdotjs/svg.js' {
     constructor(node?: SVGGElement)
     constructor(attr: object)
     node: SVGGElement
-    gbox(): Box
   }
 
   // hyperlink.js


### PR DESCRIPTION
The method has not existed since c37d94a.